### PR TITLE
Allow author skip format check failure

### DIFF
--- a/scripts/pre-commit.hook
+++ b/scripts/pre-commit.hook
@@ -50,4 +50,21 @@ if [ $? -ne 0 ]; then
     echo
 fi
 
+if [ ${RETURN} -ne 0 ]; then
+	if tty >/dev/null 2>&1; then
+	  TTY=$(tty)
+	else
+	  TTY=/dev/tty
+	fi
+
+	echo -en "Some checks fail on your source code.\nIf you insist to commit, you might face angry reviewers.\nProceed anyway? [N/y/?] "
+	# Read the answer
+	read REPLY < "$TTY"
+
+	case "$REPLY" in
+	Y*|y*) RETURN=0 ;;
+	*)     ;; # fall to fail
+	esac
+fi
+
 exit $RETURN


### PR DESCRIPTION
Unify coding style is good, but sometimes the style doesn't match the running style of editing file, or something else. It will be good if we allow programmer to use their judgement on this topic.

for example, I created an array of struct attribute for my attribute_group, but clang-format think all attributes should be declared in single line.
```
 static struct attribute *attrs[] = {                               
-    &result_attribute.attr,                                        
-    &reset_attribute.attr,                                         
+    &result_attribute.attr, &reset_attribute.attr,                 
     NULL, /* need to NULL terminate the list of attributes */      
 };                                                                 
```