### PR TITLE
Add GitHub Action scripts for automated testing

### DIFF
--- a/.ci/check-format.sh
+++ b/.ci/check-format.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+SOURCES=$(find $(git rev-parse --show-toplevel) | egrep "\.(cpp|h)\$")
+
+set -x
+
+for file in ${SOURCES};
+do
+    clang-format-14 ${file} > expected-format
+    diff -u -p --label="${file}" --label="expected coding style" ${file} expected-format
+done
+exit $(clang-format-14 --output-replacements-xml ${SOURCES} | egrep -c "</replacement>")

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,30 @@
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  fibdrv-check:
+    runs-on: ubuntu-22.04
+    steps:
+    - uses: actions/checkout@v3.3.0
+    - name: install-dependencies
+      run: |
+            sudo apt-get update
+            sudo apt-get -q -y install build-essential cppcheck
+            sudo apt-get -q -y install linux-headers-`uname -r`
+    - name: make
+      run:  |
+            make
+    - name: make check
+      run: |
+            make check
+
+  coding-style:
+    runs-on: ubuntu-22.04
+    steps:
+    - uses: actions/checkout@v3.3.0
+    - name: coding convention
+      run: |
+            sudo apt-get install -q -y clang-format-14
+            sh .ci/check-format.sh
+      shell: bash


### PR DESCRIPTION
This commit add two jobs for GitHub Action:

- fibdrv-check: It will execute `make` and `make check` to ensure that the kernel module can be successfully built, loaded and used.

- coding-style: It will check the coding-style using clang-format.