### PR TITLE
Add compile argument to get intermediate files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,8 @@ CONFIG_MODULE_SIG = n
 TARGET_MODULE := fibdrv
 
 obj-m := $(TARGET_MODULE).o
-ccflags-y := -std=gnu99 -Wno-declaration-after-statement
+ccflags-y := -std=gnu99 -Wno-declaration-after-statement -save-temps
+
 
 KDIR := /lib/modules/$(shell uname -r)/build
 PWD := $(shell pwd)


### PR DESCRIPTION
This commit add -save-temps compile argument
- *.i file is Preprocessor Output
- *.s file is Assembler output