### PR TITLE
Fixed some minor issues.

### DIFF
--- a/fibdrv.c
+++ b/fibdrv.c
@@ -42,7 +42,7 @@ static long long fib_sequence(long long k)
 static int fib_open(struct inode *inode, struct file *file)
 {
     if (!mutex_trylock(&fib_mutex)) {
-        printk(KERN_ALERT "fibdrv is in use");
+        printk(KERN_ALERT "fibdrv is in use\n");
         return -EBUSY;
     }
     return 0;
@@ -113,7 +113,7 @@ static int __init init_fib_dev(void)
     // This will dynamically allocate the major number
     rc = major = register_chrdev(major, DEV_FIBONACCI_NAME, &fib_fops);
     if (rc < 0) {
-        printk(KERN_ALERT "Failed to add cdev");
+        printk(KERN_ALERT "Failed to add cdev\n");
         rc = -2;
         goto failed_cdev;
     }
@@ -122,17 +122,17 @@ static int __init init_fib_dev(void)
     fib_class = class_create(THIS_MODULE, DEV_FIBONACCI_NAME);
 
     if (!fib_class) {
-        printk(KERN_ALERT "Failed to create device class");
+        printk(KERN_ALERT "Failed to create device class\n");
         rc = -3;
         goto failed_class_create;
     }
 
     if (!device_create(fib_class, NULL, fib_dev, NULL, DEV_FIBONACCI_NAME)) {
-        printk(KERN_ALERT "Failed to create device");
+        printk(KERN_ALERT "Failed to create device\n");
         rc = -4;
         goto failed_device_create;
     }
-    return rc;
+    return rc - major;
 failed_device_create:
     class_destroy(fib_class);
 failed_class_create:

--- a/fibdrv.c
+++ b/fibdrv.c
@@ -20,9 +20,10 @@ MODULE_VERSION("0.1");
 #define MAX_LENGTH 92
 
 static dev_t fib_dev = 0;
-static struct cdev *fib_cdev;
 static struct class *fib_class;
 static DEFINE_MUTEX(fib_mutex);
+static int major = 0;
+static int minor = 0;
 
 static long long fib_sequence(long long k)
 {
@@ -107,34 +108,18 @@ const struct file_operations fib_fops = {
 static int __init init_fib_dev(void)
 {
     int rc = 0;
-
     mutex_init(&fib_mutex);
 
     // Let's register the device
     // This will dynamically allocate the major number
-    rc = alloc_chrdev_region(&fib_dev, 0, 1, DEV_FIBONACCI_NAME);
-
-    if (rc < 0) {
-        printk(KERN_ALERT
-               "Failed to register the fibonacci char device. rc = %i",
-               rc);
-        return rc;
-    }
-
-    fib_cdev = cdev_alloc();
-    if (fib_cdev == NULL) {
-        printk(KERN_ALERT "Failed to alloc cdev");
-        rc = -1;
-        goto failed_cdev;
-    }
-    fib_cdev->ops = &fib_fops;
-    rc = cdev_add(fib_cdev, fib_dev, 1);
-
+    major = register_chrdev(major, DEV_FIBONACCI_NAME, &fib_fops);
+    rc = major;
     if (rc < 0) {
         printk(KERN_ALERT "Failed to add cdev");
         rc = -2;
         goto failed_cdev;
     }
+    fib_dev = MKDEV(major, minor);
 
     fib_class = class_create(THIS_MODULE, DEV_FIBONACCI_NAME);
 
@@ -153,9 +138,8 @@ static int __init init_fib_dev(void)
 failed_device_create:
     class_destroy(fib_class);
 failed_class_create:
-    cdev_del(fib_cdev);
 failed_cdev:
-    unregister_chrdev_region(fib_dev, 1);
+    unregister_chrdev(major, DEV_FIBONACCI_NAME);
     return rc;
 }
 
@@ -164,8 +148,7 @@ static void __exit exit_fib_dev(void)
     mutex_destroy(&fib_mutex);
     device_destroy(fib_class, fib_dev);
     class_destroy(fib_class);
-    cdev_del(fib_cdev);
-    unregister_chrdev_region(fib_dev, 1);
+    unregister_chrdev(major, DEV_FIBONACCI_NAME);
 }
 
 module_init(init_fib_dev);

--- a/fibdrv.c
+++ b/fibdrv.c
@@ -22,8 +22,7 @@ MODULE_VERSION("0.1");
 static dev_t fib_dev = 0;
 static struct class *fib_class;
 static DEFINE_MUTEX(fib_mutex);
-static int major = 0;
-static int minor = 0;
+static int major = 0, minor = 0;
 
 static long long fib_sequence(long long k)
 {
@@ -112,8 +111,7 @@ static int __init init_fib_dev(void)
 
     // Let's register the device
     // This will dynamically allocate the major number
-    major = register_chrdev(major, DEV_FIBONACCI_NAME, &fib_fops);
-    rc = major;
+    rc = major = register_chrdev(major, DEV_FIBONACCI_NAME, &fib_fops);
     if (rc < 0) {
         printk(KERN_ALERT "Failed to add cdev");
         rc = -2;


### PR DESCRIPTION
I append \n to each string in printk so that it is immediately flushed to the kernel logs. The return value of rc in fib_open() has also been modified to raise a kernel warning if it returns a nonzero value.