### PR TITLE
Enhance upper bound of Fibonacci driver

### DIFF
--- a/client.c
+++ b/client.c
@@ -11,9 +11,9 @@ int main()
 {
     long long sz;
 
-    char buf[1];
+    char buf[256] = {0};
     char write_buf[] = "testing writing";
-    int offset = 100; /* TODO: try test something bigger than the limit */
+    int offset = 1000; /* TODO: try test something bigger than the limit */
 
     int fd = open(FIB_DEV, O_RDWR);
     if (fd < 0) {
@@ -28,20 +28,22 @@ int main()
 
     for (int i = 0; i <= offset; i++) {
         lseek(fd, i, SEEK_SET);
-        sz = read(fd, buf, 1);
+        sz = read(fd, &buf, sizeof(buf));
+        buf[sz] = '\0';
         printf("Reading from " FIB_DEV
                " at offset %d, returned the sequence "
-               "%lld.\n",
-               i, sz);
+               "%s.\n",
+               i, buf);
     }
 
     for (int i = offset; i >= 0; i--) {
         lseek(fd, i, SEEK_SET);
-        sz = read(fd, buf, 1);
+        sz = read(fd, &buf, sizeof(buf));
+        buf[sz] = '\0';
         printf("Reading from " FIB_DEV
                " at offset %d, returned the sequence "
-               "%lld.\n",
-               i, sz);
+               "%s.\n",
+               i, buf);
     }
 
     close(fd);

--- a/scripts/expected.txt
+++ b/scripts/expected.txt
@@ -99,6 +99,906 @@ Writing to /dev/fibonacci, returned the sequence 1
 Writing to /dev/fibonacci, returned the sequence 1
 Writing to /dev/fibonacci, returned the sequence 1
 Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
+Writing to /dev/fibonacci, returned the sequence 1
 Reading from /dev/fibonacci at offset 0, returned the sequence 0.
 Reading from /dev/fibonacci at offset 1, returned the sequence 1.
 Reading from /dev/fibonacci at offset 2, returned the sequence 1.
@@ -192,22 +1092,1822 @@ Reading from /dev/fibonacci at offset 89, returned the sequence 1779979416004714
 Reading from /dev/fibonacci at offset 90, returned the sequence 2880067194370816120.
 Reading from /dev/fibonacci at offset 91, returned the sequence 4660046610375530309.
 Reading from /dev/fibonacci at offset 92, returned the sequence 7540113804746346429.
-Reading from /dev/fibonacci at offset 93, returned the sequence 7540113804746346429.
-Reading from /dev/fibonacci at offset 94, returned the sequence 7540113804746346429.
-Reading from /dev/fibonacci at offset 95, returned the sequence 7540113804746346429.
-Reading from /dev/fibonacci at offset 96, returned the sequence 7540113804746346429.
-Reading from /dev/fibonacci at offset 97, returned the sequence 7540113804746346429.
-Reading from /dev/fibonacci at offset 98, returned the sequence 7540113804746346429.
-Reading from /dev/fibonacci at offset 99, returned the sequence 7540113804746346429.
-Reading from /dev/fibonacci at offset 100, returned the sequence 7540113804746346429.
-Reading from /dev/fibonacci at offset 100, returned the sequence 7540113804746346429.
-Reading from /dev/fibonacci at offset 99, returned the sequence 7540113804746346429.
-Reading from /dev/fibonacci at offset 98, returned the sequence 7540113804746346429.
-Reading from /dev/fibonacci at offset 97, returned the sequence 7540113804746346429.
-Reading from /dev/fibonacci at offset 96, returned the sequence 7540113804746346429.
-Reading from /dev/fibonacci at offset 95, returned the sequence 7540113804746346429.
-Reading from /dev/fibonacci at offset 94, returned the sequence 7540113804746346429.
-Reading from /dev/fibonacci at offset 93, returned the sequence 7540113804746346429.
+Reading from /dev/fibonacci at offset 93, returned the sequence 12200160415121876738.
+Reading from /dev/fibonacci at offset 94, returned the sequence 19740274219868223167.
+Reading from /dev/fibonacci at offset 95, returned the sequence 31940434634990099905.
+Reading from /dev/fibonacci at offset 96, returned the sequence 51680708854858323072.
+Reading from /dev/fibonacci at offset 97, returned the sequence 83621143489848422977.
+Reading from /dev/fibonacci at offset 98, returned the sequence 135301852344706746049.
+Reading from /dev/fibonacci at offset 99, returned the sequence 218922995834555169026.
+Reading from /dev/fibonacci at offset 100, returned the sequence 354224848179261915075.
+Reading from /dev/fibonacci at offset 101, returned the sequence 573147844013817084101.
+Reading from /dev/fibonacci at offset 102, returned the sequence 927372692193078999176.
+Reading from /dev/fibonacci at offset 103, returned the sequence 1500520536206896083277.
+Reading from /dev/fibonacci at offset 104, returned the sequence 2427893228399975082453.
+Reading from /dev/fibonacci at offset 105, returned the sequence 3928413764606871165730.
+Reading from /dev/fibonacci at offset 106, returned the sequence 6356306993006846248183.
+Reading from /dev/fibonacci at offset 107, returned the sequence 10284720757613717413913.
+Reading from /dev/fibonacci at offset 108, returned the sequence 16641027750620563662096.
+Reading from /dev/fibonacci at offset 109, returned the sequence 26925748508234281076009.
+Reading from /dev/fibonacci at offset 110, returned the sequence 43566776258854844738105.
+Reading from /dev/fibonacci at offset 111, returned the sequence 70492524767089125814114.
+Reading from /dev/fibonacci at offset 112, returned the sequence 114059301025943970552219.
+Reading from /dev/fibonacci at offset 113, returned the sequence 184551825793033096366333.
+Reading from /dev/fibonacci at offset 114, returned the sequence 298611126818977066918552.
+Reading from /dev/fibonacci at offset 115, returned the sequence 483162952612010163284885.
+Reading from /dev/fibonacci at offset 116, returned the sequence 781774079430987230203437.
+Reading from /dev/fibonacci at offset 117, returned the sequence 1264937032042997393488322.
+Reading from /dev/fibonacci at offset 118, returned the sequence 2046711111473984623691759.
+Reading from /dev/fibonacci at offset 119, returned the sequence 3311648143516982017180081.
+Reading from /dev/fibonacci at offset 120, returned the sequence 5358359254990966640871840.
+Reading from /dev/fibonacci at offset 121, returned the sequence 8670007398507948658051921.
+Reading from /dev/fibonacci at offset 122, returned the sequence 14028366653498915298923761.
+Reading from /dev/fibonacci at offset 123, returned the sequence 22698374052006863956975682.
+Reading from /dev/fibonacci at offset 124, returned the sequence 36726740705505779255899443.
+Reading from /dev/fibonacci at offset 125, returned the sequence 59425114757512643212875125.
+Reading from /dev/fibonacci at offset 126, returned the sequence 96151855463018422468774568.
+Reading from /dev/fibonacci at offset 127, returned the sequence 155576970220531065681649693.
+Reading from /dev/fibonacci at offset 128, returned the sequence 251728825683549488150424261.
+Reading from /dev/fibonacci at offset 129, returned the sequence 407305795904080553832073954.
+Reading from /dev/fibonacci at offset 130, returned the sequence 659034621587630041982498215.
+Reading from /dev/fibonacci at offset 131, returned the sequence 1066340417491710595814572169.
+Reading from /dev/fibonacci at offset 132, returned the sequence 1725375039079340637797070384.
+Reading from /dev/fibonacci at offset 133, returned the sequence 2791715456571051233611642553.
+Reading from /dev/fibonacci at offset 134, returned the sequence 4517090495650391871408712937.
+Reading from /dev/fibonacci at offset 135, returned the sequence 7308805952221443105020355490.
+Reading from /dev/fibonacci at offset 136, returned the sequence 11825896447871834976429068427.
+Reading from /dev/fibonacci at offset 137, returned the sequence 19134702400093278081449423917.
+Reading from /dev/fibonacci at offset 138, returned the sequence 30960598847965113057878492344.
+Reading from /dev/fibonacci at offset 139, returned the sequence 50095301248058391139327916261.
+Reading from /dev/fibonacci at offset 140, returned the sequence 81055900096023504197206408605.
+Reading from /dev/fibonacci at offset 141, returned the sequence 131151201344081895336534324866.
+Reading from /dev/fibonacci at offset 142, returned the sequence 212207101440105399533740733471.
+Reading from /dev/fibonacci at offset 143, returned the sequence 343358302784187294870275058337.
+Reading from /dev/fibonacci at offset 144, returned the sequence 555565404224292694404015791808.
+Reading from /dev/fibonacci at offset 145, returned the sequence 898923707008479989274290850145.
+Reading from /dev/fibonacci at offset 146, returned the sequence 1454489111232772683678306641953.
+Reading from /dev/fibonacci at offset 147, returned the sequence 2353412818241252672952597492098.
+Reading from /dev/fibonacci at offset 148, returned the sequence 3807901929474025356630904134051.
+Reading from /dev/fibonacci at offset 149, returned the sequence 6161314747715278029583501626149.
+Reading from /dev/fibonacci at offset 150, returned the sequence 9969216677189303386214405760200.
+Reading from /dev/fibonacci at offset 151, returned the sequence 16130531424904581415797907386349.
+Reading from /dev/fibonacci at offset 152, returned the sequence 26099748102093884802012313146549.
+Reading from /dev/fibonacci at offset 153, returned the sequence 42230279526998466217810220532898.
+Reading from /dev/fibonacci at offset 154, returned the sequence 68330027629092351019822533679447.
+Reading from /dev/fibonacci at offset 155, returned the sequence 110560307156090817237632754212345.
+Reading from /dev/fibonacci at offset 156, returned the sequence 178890334785183168257455287891792.
+Reading from /dev/fibonacci at offset 157, returned the sequence 289450641941273985495088042104137.
+Reading from /dev/fibonacci at offset 158, returned the sequence 468340976726457153752543329995929.
+Reading from /dev/fibonacci at offset 159, returned the sequence 757791618667731139247631372100066.
+Reading from /dev/fibonacci at offset 160, returned the sequence 1226132595394188293000174702095995.
+Reading from /dev/fibonacci at offset 161, returned the sequence 1983924214061919432247806074196061.
+Reading from /dev/fibonacci at offset 162, returned the sequence 3210056809456107725247980776292056.
+Reading from /dev/fibonacci at offset 163, returned the sequence 5193981023518027157495786850488117.
+Reading from /dev/fibonacci at offset 164, returned the sequence 8404037832974134882743767626780173.
+Reading from /dev/fibonacci at offset 165, returned the sequence 13598018856492162040239554477268290.
+Reading from /dev/fibonacci at offset 166, returned the sequence 22002056689466296922983322104048463.
+Reading from /dev/fibonacci at offset 167, returned the sequence 35600075545958458963222876581316753.
+Reading from /dev/fibonacci at offset 168, returned the sequence 57602132235424755886206198685365216.
+Reading from /dev/fibonacci at offset 169, returned the sequence 93202207781383214849429075266681969.
+Reading from /dev/fibonacci at offset 170, returned the sequence 150804340016807970735635273952047185.
+Reading from /dev/fibonacci at offset 171, returned the sequence 244006547798191185585064349218729154.
+Reading from /dev/fibonacci at offset 172, returned the sequence 394810887814999156320699623170776339.
+Reading from /dev/fibonacci at offset 173, returned the sequence 638817435613190341905763972389505493.
+Reading from /dev/fibonacci at offset 174, returned the sequence 1033628323428189498226463595560281832.
+Reading from /dev/fibonacci at offset 175, returned the sequence 1672445759041379840132227567949787325.
+Reading from /dev/fibonacci at offset 176, returned the sequence 2706074082469569338358691163510069157.
+Reading from /dev/fibonacci at offset 177, returned the sequence 4378519841510949178490918731459856482.
+Reading from /dev/fibonacci at offset 178, returned the sequence 7084593923980518516849609894969925639.
+Reading from /dev/fibonacci at offset 179, returned the sequence 11463113765491467695340528626429782121.
+Reading from /dev/fibonacci at offset 180, returned the sequence 18547707689471986212190138521399707760.
+Reading from /dev/fibonacci at offset 181, returned the sequence 30010821454963453907530667147829489881.
+Reading from /dev/fibonacci at offset 182, returned the sequence 48558529144435440119720805669229197641.
+Reading from /dev/fibonacci at offset 183, returned the sequence 78569350599398894027251472817058687522.
+Reading from /dev/fibonacci at offset 184, returned the sequence 127127879743834334146972278486287885163.
+Reading from /dev/fibonacci at offset 185, returned the sequence 205697230343233228174223751303346572685.
+Reading from /dev/fibonacci at offset 186, returned the sequence 332825110087067562321196029789634457848.
+Reading from /dev/fibonacci at offset 187, returned the sequence 538522340430300790495419781092981030533.
+Reading from /dev/fibonacci at offset 188, returned the sequence 871347450517368352816615810882615488381.
+Reading from /dev/fibonacci at offset 189, returned the sequence 1409869790947669143312035591975596518914.
+Reading from /dev/fibonacci at offset 190, returned the sequence 2281217241465037496128651402858212007295.
+Reading from /dev/fibonacci at offset 191, returned the sequence 3691087032412706639440686994833808526209.
+Reading from /dev/fibonacci at offset 192, returned the sequence 5972304273877744135569338397692020533504.
+Reading from /dev/fibonacci at offset 193, returned the sequence 9663391306290450775010025392525829059713.
+Reading from /dev/fibonacci at offset 194, returned the sequence 15635695580168194910579363790217849593217.
+Reading from /dev/fibonacci at offset 195, returned the sequence 25299086886458645685589389182743678652930.
+Reading from /dev/fibonacci at offset 196, returned the sequence 40934782466626840596168752972961528246147.
+Reading from /dev/fibonacci at offset 197, returned the sequence 66233869353085486281758142155705206899077.
+Reading from /dev/fibonacci at offset 198, returned the sequence 107168651819712326877926895128666735145224.
+Reading from /dev/fibonacci at offset 199, returned the sequence 173402521172797813159685037284371942044301.
+Reading from /dev/fibonacci at offset 200, returned the sequence 280571172992510140037611932413038677189525.
+Reading from /dev/fibonacci at offset 201, returned the sequence 453973694165307953197296969697410619233826.
+Reading from /dev/fibonacci at offset 202, returned the sequence 734544867157818093234908902110449296423351.
+Reading from /dev/fibonacci at offset 203, returned the sequence 1188518561323126046432205871807859915657177.
+Reading from /dev/fibonacci at offset 204, returned the sequence 1923063428480944139667114773918309212080528.
+Reading from /dev/fibonacci at offset 205, returned the sequence 3111581989804070186099320645726169127737705.
+Reading from /dev/fibonacci at offset 206, returned the sequence 5034645418285014325766435419644478339818233.
+Reading from /dev/fibonacci at offset 207, returned the sequence 8146227408089084511865756065370647467555938.
+Reading from /dev/fibonacci at offset 208, returned the sequence 13180872826374098837632191485015125807374171.
+Reading from /dev/fibonacci at offset 209, returned the sequence 21327100234463183349497947550385773274930109.
+Reading from /dev/fibonacci at offset 210, returned the sequence 34507973060837282187130139035400899082304280.
+Reading from /dev/fibonacci at offset 211, returned the sequence 55835073295300465536628086585786672357234389.
+Reading from /dev/fibonacci at offset 212, returned the sequence 90343046356137747723758225621187571439538669.
+Reading from /dev/fibonacci at offset 213, returned the sequence 146178119651438213260386312206974243796773058.
+Reading from /dev/fibonacci at offset 214, returned the sequence 236521166007575960984144537828161815236311727.
+Reading from /dev/fibonacci at offset 215, returned the sequence 382699285659014174244530850035136059033084785.
+Reading from /dev/fibonacci at offset 216, returned the sequence 619220451666590135228675387863297874269396512.
+Reading from /dev/fibonacci at offset 217, returned the sequence 1001919737325604309473206237898433933302481297.
+Reading from /dev/fibonacci at offset 218, returned the sequence 1621140188992194444701881625761731807571877809.
+Reading from /dev/fibonacci at offset 219, returned the sequence 2623059926317798754175087863660165740874359106.
+Reading from /dev/fibonacci at offset 220, returned the sequence 4244200115309993198876969489421897548446236915.
+Reading from /dev/fibonacci at offset 221, returned the sequence 6867260041627791953052057353082063289320596021.
+Reading from /dev/fibonacci at offset 222, returned the sequence 11111460156937785151929026842503960837766832936.
+Reading from /dev/fibonacci at offset 223, returned the sequence 17978720198565577104981084195586024127087428957.
+Reading from /dev/fibonacci at offset 224, returned the sequence 29090180355503362256910111038089984964854261893.
+Reading from /dev/fibonacci at offset 225, returned the sequence 47068900554068939361891195233676009091941690850.
+Reading from /dev/fibonacci at offset 226, returned the sequence 76159080909572301618801306271765994056795952743.
+Reading from /dev/fibonacci at offset 227, returned the sequence 123227981463641240980692501505442003148737643593.
+Reading from /dev/fibonacci at offset 228, returned the sequence 199387062373213542599493807777207997205533596336.
+Reading from /dev/fibonacci at offset 229, returned the sequence 322615043836854783580186309282650000354271239929.
+Reading from /dev/fibonacci at offset 230, returned the sequence 522002106210068326179680117059857997559804836265.
+Reading from /dev/fibonacci at offset 231, returned the sequence 844617150046923109759866426342507997914076076194.
+Reading from /dev/fibonacci at offset 232, returned the sequence 1366619256256991435939546543402365995473880912459.
+Reading from /dev/fibonacci at offset 233, returned the sequence 2211236406303914545699412969744873993387956988653.
+Reading from /dev/fibonacci at offset 234, returned the sequence 3577855662560905981638959513147239988861837901112.
+Reading from /dev/fibonacci at offset 235, returned the sequence 5789092068864820527338372482892113982249794889765.
+Reading from /dev/fibonacci at offset 236, returned the sequence 9366947731425726508977331996039353971111632790877.
+Reading from /dev/fibonacci at offset 237, returned the sequence 15156039800290547036315704478931467953361427680642.
+Reading from /dev/fibonacci at offset 238, returned the sequence 24522987531716273545293036474970821924473060471519.
+Reading from /dev/fibonacci at offset 239, returned the sequence 39679027332006820581608740953902289877834488152161.
+Reading from /dev/fibonacci at offset 240, returned the sequence 64202014863723094126901777428873111802307548623680.
+Reading from /dev/fibonacci at offset 241, returned the sequence 103881042195729914708510518382775401680142036775841.
+Reading from /dev/fibonacci at offset 242, returned the sequence 168083057059453008835412295811648513482449585399521.
+Reading from /dev/fibonacci at offset 243, returned the sequence 271964099255182923543922814194423915162591622175362.
+Reading from /dev/fibonacci at offset 244, returned the sequence 440047156314635932379335110006072428645041207574883.
+Reading from /dev/fibonacci at offset 245, returned the sequence 712011255569818855923257924200496343807632829750245.
+Reading from /dev/fibonacci at offset 246, returned the sequence 1152058411884454788302593034206568772452674037325128.
+Reading from /dev/fibonacci at offset 247, returned the sequence 1864069667454273644225850958407065116260306867075373.
+Reading from /dev/fibonacci at offset 248, returned the sequence 3016128079338728432528443992613633888712980904400501.
+Reading from /dev/fibonacci at offset 249, returned the sequence 4880197746793002076754294951020699004973287771475874.
+Reading from /dev/fibonacci at offset 250, returned the sequence 7896325826131730509282738943634332893686268675876375.
+Reading from /dev/fibonacci at offset 251, returned the sequence 12776523572924732586037033894655031898659556447352249.
+Reading from /dev/fibonacci at offset 252, returned the sequence 20672849399056463095319772838289364792345825123228624.
+Reading from /dev/fibonacci at offset 253, returned the sequence 33449372971981195681356806732944396691005381570580873.
+Reading from /dev/fibonacci at offset 254, returned the sequence 54122222371037658776676579571233761483351206693809497.
+Reading from /dev/fibonacci at offset 255, returned the sequence 87571595343018854458033386304178158174356588264390370.
+Reading from /dev/fibonacci at offset 256, returned the sequence 141693817714056513234709965875411919657707794958199867.
+Reading from /dev/fibonacci at offset 257, returned the sequence 229265413057075367692743352179590077832064383222590237.
+Reading from /dev/fibonacci at offset 258, returned the sequence 370959230771131880927453318055001997489772178180790104.
+Reading from /dev/fibonacci at offset 259, returned the sequence 600224643828207248620196670234592075321836561403380341.
+Reading from /dev/fibonacci at offset 260, returned the sequence 971183874599339129547649988289594072811608739584170445.
+Reading from /dev/fibonacci at offset 261, returned the sequence 1571408518427546378167846658524186148133445300987550786.
+Reading from /dev/fibonacci at offset 262, returned the sequence 2542592393026885507715496646813780220945054040571721231.
+Reading from /dev/fibonacci at offset 263, returned the sequence 4114000911454431885883343305337966369078499341559272017.
+Reading from /dev/fibonacci at offset 264, returned the sequence 6656593304481317393598839952151746590023553382130993248.
+Reading from /dev/fibonacci at offset 265, returned the sequence 10770594215935749279482183257489712959102052723690265265.
+Reading from /dev/fibonacci at offset 266, returned the sequence 17427187520417066673081023209641459549125606105821258513.
+Reading from /dev/fibonacci at offset 267, returned the sequence 28197781736352815952563206467131172508227658829511523778.
+Reading from /dev/fibonacci at offset 268, returned the sequence 45624969256769882625644229676772632057353264935332782291.
+Reading from /dev/fibonacci at offset 269, returned the sequence 73822750993122698578207436143903804565580923764844306069.
+Reading from /dev/fibonacci at offset 270, returned the sequence 119447720249892581203851665820676436622934188700177088360.
+Reading from /dev/fibonacci at offset 271, returned the sequence 193270471243015279782059101964580241188515112465021394429.
+Reading from /dev/fibonacci at offset 272, returned the sequence 312718191492907860985910767785256677811449301165198482789.
+Reading from /dev/fibonacci at offset 273, returned the sequence 505988662735923140767969869749836918999964413630219877218.
+Reading from /dev/fibonacci at offset 274, returned the sequence 818706854228831001753880637535093596811413714795418360007.
+Reading from /dev/fibonacci at offset 275, returned the sequence 1324695516964754142521850507284930515811378128425638237225.
+Reading from /dev/fibonacci at offset 276, returned the sequence 2143402371193585144275731144820024112622791843221056597232.
+Reading from /dev/fibonacci at offset 277, returned the sequence 3468097888158339286797581652104954628434169971646694834457.
+Reading from /dev/fibonacci at offset 278, returned the sequence 5611500259351924431073312796924978741056961814867751431689.
+Reading from /dev/fibonacci at offset 279, returned the sequence 9079598147510263717870894449029933369491131786514446266146.
+Reading from /dev/fibonacci at offset 280, returned the sequence 14691098406862188148944207245954912110548093601382197697835.
+Reading from /dev/fibonacci at offset 281, returned the sequence 23770696554372451866815101694984845480039225387896643963981.
+Reading from /dev/fibonacci at offset 282, returned the sequence 38461794961234640015759308940939757590587318989278841661816.
+Reading from /dev/fibonacci at offset 283, returned the sequence 62232491515607091882574410635924603070626544377175485625797.
+Reading from /dev/fibonacci at offset 284, returned the sequence 100694286476841731898333719576864360661213863366454327287613.
+Reading from /dev/fibonacci at offset 285, returned the sequence 162926777992448823780908130212788963731840407743629812913410.
+Reading from /dev/fibonacci at offset 286, returned the sequence 263621064469290555679241849789653324393054271110084140201023.
+Reading from /dev/fibonacci at offset 287, returned the sequence 426547842461739379460149980002442288124894678853713953114433.
+Reading from /dev/fibonacci at offset 288, returned the sequence 690168906931029935139391829792095612517948949963798093315456.
+Reading from /dev/fibonacci at offset 289, returned the sequence 1116716749392769314599541809794537900642843628817512046429889.
+Reading from /dev/fibonacci at offset 290, returned the sequence 1806885656323799249738933639586633513160792578781310139745345.
+Reading from /dev/fibonacci at offset 291, returned the sequence 2923602405716568564338475449381171413803636207598822186175234.
+Reading from /dev/fibonacci at offset 292, returned the sequence 4730488062040367814077409088967804926964428786380132325920579.
+Reading from /dev/fibonacci at offset 293, returned the sequence 7654090467756936378415884538348976340768064993978954512095813.
+Reading from /dev/fibonacci at offset 294, returned the sequence 12384578529797304192493293627316781267732493780359086838016392.
+Reading from /dev/fibonacci at offset 295, returned the sequence 20038668997554240570909178165665757608500558774338041350112205.
+Reading from /dev/fibonacci at offset 296, returned the sequence 32423247527351544763402471792982538876233052554697128188128597.
+Reading from /dev/fibonacci at offset 297, returned the sequence 52461916524905785334311649958648296484733611329035169538240802.
+Reading from /dev/fibonacci at offset 298, returned the sequence 84885164052257330097714121751630835360966663883732297726369399.
+Reading from /dev/fibonacci at offset 299, returned the sequence 137347080577163115432025771710279131845700275212767467264610201.
+Reading from /dev/fibonacci at offset 300, returned the sequence 222232244629420445529739893461909967206666939096499764990979600.
+Reading from /dev/fibonacci at offset 301, returned the sequence 359579325206583560961765665172189099052367214309267232255589801.
+Reading from /dev/fibonacci at offset 302, returned the sequence 581811569836004006491505558634099066259034153405766997246569401.
+Reading from /dev/fibonacci at offset 303, returned the sequence 941390895042587567453271223806288165311401367715034229502159202.
+Reading from /dev/fibonacci at offset 304, returned the sequence 1523202464878591573944776782440387231570435521120801226748728603.
+Reading from /dev/fibonacci at offset 305, returned the sequence 2464593359921179141398048006246675396881836888835835456250887805.
+Reading from /dev/fibonacci at offset 306, returned the sequence 3987795824799770715342824788687062628452272409956636682999616408.
+Reading from /dev/fibonacci at offset 307, returned the sequence 6452389184720949856740872794933738025334109298792472139250504213.
+Reading from /dev/fibonacci at offset 308, returned the sequence 10440185009520720572083697583620800653786381708749108822250120621.
+Reading from /dev/fibonacci at offset 309, returned the sequence 16892574194241670428824570378554538679120491007541580961500624834.
+Reading from /dev/fibonacci at offset 310, returned the sequence 27332759203762391000908267962175339332906872716290689783750745455.
+Reading from /dev/fibonacci at offset 311, returned the sequence 44225333398004061429732838340729878012027363723832270745251370289.
+Reading from /dev/fibonacci at offset 312, returned the sequence 71558092601766452430641106302905217344934236440122960529002115744.
+Reading from /dev/fibonacci at offset 313, returned the sequence 115783425999770513860373944643635095356961600163955231274253486033.
+Reading from /dev/fibonacci at offset 314, returned the sequence 187341518601536966291015050946540312701895836604078191803255601777.
+Reading from /dev/fibonacci at offset 315, returned the sequence 303124944601307480151388995590175408058857436768033423077509087810.
+Reading from /dev/fibonacci at offset 316, returned the sequence 490466463202844446442404046536715720760753273372111614880764689587.
+Reading from /dev/fibonacci at offset 317, returned the sequence 793591407804151926593793042126891128819610710140145037958273777397.
+Reading from /dev/fibonacci at offset 318, returned the sequence 1284057871006996373036197088663606849580363983512256652839038466984.
+Reading from /dev/fibonacci at offset 319, returned the sequence 2077649278811148299629990130790497978399974693652401690797312244381.
+Reading from /dev/fibonacci at offset 320, returned the sequence 3361707149818144672666187219454104827980338677164658343636350711365.
+Reading from /dev/fibonacci at offset 321, returned the sequence 5439356428629292972296177350244602806380313370817060034433662955746.
+Reading from /dev/fibonacci at offset 322, returned the sequence 8801063578447437644962364569698707634360652047981718378070013667111.
+Reading from /dev/fibonacci at offset 323, returned the sequence 14240420007076730617258541919943310440740965418798778412503676622857.
+Reading from /dev/fibonacci at offset 324, returned the sequence 23041483585524168262220906489642018075101617466780496790573690289968.
+Reading from /dev/fibonacci at offset 325, returned the sequence 37281903592600898879479448409585328515842582885579275203077366912825.
+Reading from /dev/fibonacci at offset 326, returned the sequence 60323387178125067141700354899227346590944200352359771993651057202793.
+Reading from /dev/fibonacci at offset 327, returned the sequence 97605290770725966021179803308812675106786783237939047196728424115618.
+Reading from /dev/fibonacci at offset 328, returned the sequence 157928677948851033162880158208040021697730983590298819190379481318411.
+Reading from /dev/fibonacci at offset 329, returned the sequence 255533968719576999184059961516852696804517766828237866387107905434029.
+Reading from /dev/fibonacci at offset 330, returned the sequence 413462646668428032346940119724892718502248750418536685577487386752440.
+Reading from /dev/fibonacci at offset 331, returned the sequence 668996615388005031531000081241745415306766517246774551964595292186469.
+Reading from /dev/fibonacci at offset 332, returned the sequence 1082459262056433063877940200966638133809015267665311237542082678938909.
+Reading from /dev/fibonacci at offset 333, returned the sequence 1751455877444438095408940282208383549115781784912085789506677971125378.
+Reading from /dev/fibonacci at offset 334, returned the sequence 2833915139500871159286880483175021682924797052577397027048760650064287.
+Reading from /dev/fibonacci at offset 335, returned the sequence 4585371016945309254695820765383405232040578837489482816555438621189665.
+Reading from /dev/fibonacci at offset 336, returned the sequence 7419286156446180413982701248558426914965375890066879843604199271253952.
+Reading from /dev/fibonacci at offset 337, returned the sequence 12004657173391489668678522013941832147005954727556362660159637892443617.
+Reading from /dev/fibonacci at offset 338, returned the sequence 19423943329837670082661223262500259061971330617623242503763837163697569.
+Reading from /dev/fibonacci at offset 339, returned the sequence 31428600503229159751339745276442091208977285345179605163923475056141186.
+Reading from /dev/fibonacci at offset 340, returned the sequence 50852543833066829834000968538942350270948615962802847667687312219838755.
+Reading from /dev/fibonacci at offset 341, returned the sequence 82281144336295989585340713815384441479925901307982452831610787275979941.
+Reading from /dev/fibonacci at offset 342, returned the sequence 133133688169362819419341682354326791750874517270785300499298099495818696.
+Reading from /dev/fibonacci at offset 343, returned the sequence 215414832505658809004682396169711233230800418578767753330908886771798637.
+Reading from /dev/fibonacci at offset 344, returned the sequence 348548520675021628424024078524038024981674935849553053830206986267617333.
+Reading from /dev/fibonacci at offset 345, returned the sequence 563963353180680437428706474693749258212475354428320807161115873039415970.
+Reading from /dev/fibonacci at offset 346, returned the sequence 912511873855702065852730553217787283194150290277873860991322859307033303.
+Reading from /dev/fibonacci at offset 347, returned the sequence 1476475227036382503281437027911536541406625644706194668152438732346449273.
+Reading from /dev/fibonacci at offset 348, returned the sequence 2388987100892084569134167581129323824600775934984068529143761591653482576.
+Reading from /dev/fibonacci at offset 349, returned the sequence 3865462327928467072415604609040860366007401579690263197296200323999931849.
+Reading from /dev/fibonacci at offset 350, returned the sequence 6254449428820551641549772190170184190608177514674331726439961915653414425.
+Reading from /dev/fibonacci at offset 351, returned the sequence 10119911756749018713965376799211044556615579094364594923736162239653346274.
+Reading from /dev/fibonacci at offset 352, returned the sequence 16374361185569570355515148989381228747223756609038926650176124155306760699.
+Reading from /dev/fibonacci at offset 353, returned the sequence 26494272942318589069480525788592273303839335703403521573912286394960106973.
+Reading from /dev/fibonacci at offset 354, returned the sequence 42868634127888159424995674777973502051063092312442448224088410550266867672.
+Reading from /dev/fibonacci at offset 355, returned the sequence 69362907070206748494476200566565775354902428015845969798000696945226974645.
+Reading from /dev/fibonacci at offset 356, returned the sequence 112231541198094907919471875344539277405965520328288418022089107495493842317.
+Reading from /dev/fibonacci at offset 357, returned the sequence 181594448268301656413948075911105052760867948344134387820089804440720816962.
+Reading from /dev/fibonacci at offset 358, returned the sequence 293825989466396564333419951255644330166833468672422805842178911936214659279.
+Reading from /dev/fibonacci at offset 359, returned the sequence 475420437734698220747368027166749382927701417016557193662268716376935476241.
+Reading from /dev/fibonacci at offset 360, returned the sequence 769246427201094785080787978422393713094534885688979999504447628313150135520.
+Reading from /dev/fibonacci at offset 361, returned the sequence 1244666864935793005828156005589143096022236302705537193166716344690085611761.
+Reading from /dev/fibonacci at offset 362, returned the sequence 2013913292136887790908943984011536809116771188394517192671163973003235747281.
+Reading from /dev/fibonacci at offset 363, returned the sequence 3258580157072680796737099989600679905139007491100054385837880317693321359042.
+Reading from /dev/fibonacci at offset 364, returned the sequence 5272493449209568587646043973612216714255778679494571578509044290696557106323.
+Reading from /dev/fibonacci at offset 365, returned the sequence 8531073606282249384383143963212896619394786170594625964346924608389878465365.
+Reading from /dev/fibonacci at offset 366, returned the sequence 13803567055491817972029187936825113333650564850089197542855968899086435571688.
+Reading from /dev/fibonacci at offset 367, returned the sequence 22334640661774067356412331900038009953045351020683823507202893507476314037053.
+Reading from /dev/fibonacci at offset 368, returned the sequence 36138207717265885328441519836863123286695915870773021050058862406562749608741.
+Reading from /dev/fibonacci at offset 369, returned the sequence 58472848379039952684853851736901133239741266891456844557261755914039063645794.
+Reading from /dev/fibonacci at offset 370, returned the sequence 94611056096305838013295371573764256526437182762229865607320618320601813254535.
+Reading from /dev/fibonacci at offset 371, returned the sequence 153083904475345790698149223310665389766178449653686710164582374234640876900329.
+Reading from /dev/fibonacci at offset 372, returned the sequence 247694960571651628711444594884429646292615632415916575771902992555242690154864.
+Reading from /dev/fibonacci at offset 373, returned the sequence 400778865046997419409593818195095036058794082069603285936485366789883567055193.
+Reading from /dev/fibonacci at offset 374, returned the sequence 648473825618649048121038413079524682351409714485519861708388359345126257210057.
+Reading from /dev/fibonacci at offset 375, returned the sequence 1049252690665646467530632231274619718410203796555123147644873726135009824265250.
+Reading from /dev/fibonacci at offset 376, returned the sequence 1697726516284295515651670644354144400761613511040643009353262085480136081475307.
+Reading from /dev/fibonacci at offset 377, returned the sequence 2746979206949941983182302875628764119171817307595766156998135811615145905740557.
+Reading from /dev/fibonacci at offset 378, returned the sequence 4444705723234237498833973519982908519933430818636409166351397897095281987215864.
+Reading from /dev/fibonacci at offset 379, returned the sequence 7191684930184179482016276395611672639105248126232175323349533708710427892956421.
+Reading from /dev/fibonacci at offset 380, returned the sequence 11636390653418416980850249915594581159038678944868584489700931605805709880172285.
+Reading from /dev/fibonacci at offset 381, returned the sequence 18828075583602596462866526311206253798143927071100759813050465314516137773128706.
+Reading from /dev/fibonacci at offset 382, returned the sequence 30464466237021013443716776226800834957182606015969344302751396920321847653300991.
+Reading from /dev/fibonacci at offset 383, returned the sequence 49292541820623609906583302538007088755326533087070104115801862234837985426429697.
+Reading from /dev/fibonacci at offset 384, returned the sequence 79757008057644623350300078764807923712509139103039448418553259155159833079730688.
+Reading from /dev/fibonacci at offset 385, returned the sequence 129049549878268233256883381302815012467835672190109552534355121389997818506160385.
+Reading from /dev/fibonacci at offset 386, returned the sequence 208806557935912856607183460067622936180344811293149000952908380545157651585891073.
+Reading from /dev/fibonacci at offset 387, returned the sequence 337856107814181089864066841370437948648180483483258553487263501935155470092051458.
+Reading from /dev/fibonacci at offset 388, returned the sequence 546662665750093946471250301438060884828525294776407554440171882480313121677942531.
+Reading from /dev/fibonacci at offset 389, returned the sequence 884518773564275036335317142808498833476705778259666107927435384415468591769993989.
+Reading from /dev/fibonacci at offset 390, returned the sequence 1431181439314368982806567444246559718305231073036073662367607266895781713447936520.
+Reading from /dev/fibonacci at offset 391, returned the sequence 2315700212878644019141884587055058551781936851295739770295042651311250305217930509.
+Reading from /dev/fibonacci at offset 392, returned the sequence 3746881652193013001948452031301618270087167924331813432662649918207032018665867029.
+Reading from /dev/fibonacci at offset 393, returned the sequence 6062581865071657021090336618356676821869104775627553202957692569518282323883797538.
+Reading from /dev/fibonacci at offset 394, returned the sequence 9809463517264670023038788649658295091956272699959366635620342487725314342549664567.
+Reading from /dev/fibonacci at offset 395, returned the sequence 15872045382336327044129125268014971913825377475586919838578035057243596666433462105.
+Reading from /dev/fibonacci at offset 396, returned the sequence 25681508899600997067167913917673267005781650175546286474198377544968911008983126672.
+Reading from /dev/fibonacci at offset 397, returned the sequence 41553554281937324111297039185688238919607027651133206312776412602212507675416588777.
+Reading from /dev/fibonacci at offset 398, returned the sequence 67235063181538321178464953103361505925388677826679492786974790147181418684399715449.
+Reading from /dev/fibonacci at offset 399, returned the sequence 108788617463475645289761992289049744844995705477812699099751202749393926359816304226.
+Reading from /dev/fibonacci at offset 400, returned the sequence 176023680645013966468226945392411250770384383304492191886725992896575345044216019675.
+Reading from /dev/fibonacci at offset 401, returned the sequence 284812298108489611757988937681460995615380088782304890986477195645969271404032323901.
+Reading from /dev/fibonacci at offset 402, returned the sequence 460835978753503578226215883073872246385764472086797082873203188542544616448248343576.
+Reading from /dev/fibonacci at offset 403, returned the sequence 745648276861993189984204820755333242001144560869101973859680384188513887852280667477.
+Reading from /dev/fibonacci at offset 404, returned the sequence 1206484255615496768210420703829205488386909032955899056732883572731058504300529011053.
+Reading from /dev/fibonacci at offset 405, returned the sequence 1952132532477489958194625524584538730388053593825001030592563956919572392152809678530.
+Reading from /dev/fibonacci at offset 406, returned the sequence 3158616788092986726405046228413744218774962626780900087325447529650630896453338689583.
+Reading from /dev/fibonacci at offset 407, returned the sequence 5110749320570476684599671752998282949163016220605901117918011486570203288606148368113.
+Reading from /dev/fibonacci at offset 408, returned the sequence 8269366108663463411004717981412027167937978847386801205243459016220834185059487057696.
+Reading from /dev/fibonacci at offset 409, returned the sequence 13380115429233940095604389734410310117100995067992702323161470502791037473665635425809.
+Reading from /dev/fibonacci at offset 410, returned the sequence 21649481537897403506609107715822337285038973915379503528404929519011871658725122483505.
+Reading from /dev/fibonacci at offset 411, returned the sequence 35029596967131343602213497450232647402139968983372205851566400021802909132390757909314.
+Reading from /dev/fibonacci at offset 412, returned the sequence 56679078505028747108822605166054984687178942898751709379971329540814780791115880392819.
+Reading from /dev/fibonacci at offset 413, returned the sequence 91708675472160090711036102616287632089318911882123915231537729562617689923506638302133.
+Reading from /dev/fibonacci at offset 414, returned the sequence 148387753977188837819858707782342616776497854780875624611509059103432470714622518694952.
+Reading from /dev/fibonacci at offset 415, returned the sequence 240096429449348928530894810398630248865816766662999539843046788666050160638129156997085.
+Reading from /dev/fibonacci at offset 416, returned the sequence 388484183426537766350753518180972865642314621443875164454555847769482631352751675692037.
+Reading from /dev/fibonacci at offset 417, returned the sequence 628580612875886694881648328579603114508131388106874704297602636435532791990880832689122.
+Reading from /dev/fibonacci at offset 418, returned the sequence 1017064796302424461232401846760575980150446009550749868752158484205015423343632508381159.
+Reading from /dev/fibonacci at offset 419, returned the sequence 1645645409178311156114050175340179094658577397657624573049761120640548215334513341070281.
+Reading from /dev/fibonacci at offset 420, returned the sequence 2662710205480735617346452022100755074809023407208374441801919604845563638678145849451440.
+Reading from /dev/fibonacci at offset 421, returned the sequence 4308355614659046773460502197440934169467600804865999014851680725486111854012659190521721.
+Reading from /dev/fibonacci at offset 422, returned the sequence 6971065820139782390806954219541689244276624212074373456653600330331675492690805039973161.
+Reading from /dev/fibonacci at offset 423, returned the sequence 11279421434798829164267456416982623413744225016940372471505281055817787346703464230494882.
+Reading from /dev/fibonacci at offset 424, returned the sequence 18250487254938611555074410636524312658020849229014745928158881386149462839394269270468043.
+Reading from /dev/fibonacci at offset 425, returned the sequence 29529908689737440719341867053506936071765074245955118399664162441967250186097733500962925.
+Reading from /dev/fibonacci at offset 426, returned the sequence 47780395944676052274416277690031248729785923474969864327823043828116713025492002771430968.
+Reading from /dev/fibonacci at offset 427, returned the sequence 77310304634413492993758144743538184801550997720924982727487206270083963211589736272393893.
+Reading from /dev/fibonacci at offset 428, returned the sequence 125090700579089545268174422433569433531336921195894847055310250098200676237081739043824861.
+Reading from /dev/fibonacci at offset 429, returned the sequence 202401005213503038261932567177107618332887918916819829782797456368284639448671475316218754.
+Reading from /dev/fibonacci at offset 430, returned the sequence 327491705792592583530106989610677051864224840112714676838107706466485315685753214360043615.
+Reading from /dev/fibonacci at offset 431, returned the sequence 529892711006095621792039556787784670197112759029534506620905162834769955134424689676262369.
+Reading from /dev/fibonacci at offset 432, returned the sequence 857384416798688205322146546398461722061337599142249183459012869301255270820177904036305984.
+Reading from /dev/fibonacci at offset 433, returned the sequence 1387277127804783827114186103186246392258450358171783690079918032136025225954602593712568353.
+Reading from /dev/fibonacci at offset 434, returned the sequence 2244661544603472032436332649584708114319787957314032873538930901437280496774780497748874337.
+Reading from /dev/fibonacci at offset 435, returned the sequence 3631938672408255859550518752770954506578238315485816563618848933573305722729383091461442690.
+Reading from /dev/fibonacci at offset 436, returned the sequence 5876600217011727891986851402355662620898026272799849437157779835010586219504163589210317027.
+Reading from /dev/fibonacci at offset 437, returned the sequence 9508538889419983751537370155126617127476264588285666000776628768583891942233546680671759717.
+Reading from /dev/fibonacci at offset 438, returned the sequence 15385139106431711643524221557482279748374290861085515437934408603594478161737710269882076744.
+Reading from /dev/fibonacci at offset 439, returned the sequence 24893677995851695395061591712608896875850555449371181438711037372178370103971256950553836461.
+Reading from /dev/fibonacci at offset 440, returned the sequence 40278817102283407038585813270091176624224846310456696876645445975772848265708967220435913205.
+Reading from /dev/fibonacci at offset 441, returned the sequence 65172495098135102433647404982700073500075401759827878315356483347951218369680224170989749666.
+Reading from /dev/fibonacci at offset 442, returned the sequence 105451312200418509472233218252791250124300248070284575192001929323724066635389191391425662871.
+Reading from /dev/fibonacci at offset 443, returned the sequence 170623807298553611905880623235491323624375649830112453507358412671675285005069415562415412537.
+Reading from /dev/fibonacci at offset 444, returned the sequence 276075119498972121378113841488282573748675897900397028699360341995399351640458606953841075408.
+Reading from /dev/fibonacci at offset 445, returned the sequence 446698926797525733283994464723773897373051547730509482206718754667074636645528022516256487945.
+Reading from /dev/fibonacci at offset 446, returned the sequence 722774046296497854662108306212056471121727445630906510906079096662473988285986629470097563353.
+Reading from /dev/fibonacci at offset 447, returned the sequence 1169472973094023587946102770935830368494778993361415993112797851329548624931514651986354051298.
+Reading from /dev/fibonacci at offset 448, returned the sequence 1892247019390521442608211077147886839616506438992322504018876947992022613217501281456451614651.
+Reading from /dev/fibonacci at offset 449, returned the sequence 3061719992484545030554313848083717208111285432353738497131674799321571238149015933442805665949.
+Reading from /dev/fibonacci at offset 450, returned the sequence 4953967011875066473162524925231604047727791871346061001150551747313593851366517214899257280600.
+Reading from /dev/fibonacci at offset 451, returned the sequence 8015687004359611503716838773315321255839077303699799498282226546635165089515533148342062946549.
+Reading from /dev/fibonacci at offset 452, returned the sequence 12969654016234677976879363698546925303566869175045860499432778293948758940882050363241320227149.
+Reading from /dev/fibonacci at offset 453, returned the sequence 20985341020594289480596202471862246559405946478745659997715004840583924030397583511583383173698.
+Reading from /dev/fibonacci at offset 454, returned the sequence 33954995036828967457475566170409171862972815653791520497147783134532682971279633874824703400847.
+Reading from /dev/fibonacci at offset 455, returned the sequence 54940336057423256938071768642271418422378762132537180494862787975116607001677217386408086574545.
+Reading from /dev/fibonacci at offset 456, returned the sequence 88895331094252224395547334812680590285351577786328700992010571109649289972956851261232789975392.
+Reading from /dev/fibonacci at offset 457, returned the sequence 143835667151675481333619103454952008707730339918865881486873359084765896974634068647640876549937.
+Reading from /dev/fibonacci at offset 458, returned the sequence 232730998245927705729166438267632598993081917705194582478883930194415186947590919908873666525329.
+Reading from /dev/fibonacci at offset 459, returned the sequence 376566665397603187062785541722584607700812257624060463965757289279181083922224988556514543075266.
+Reading from /dev/fibonacci at offset 460, returned the sequence 609297663643530892791951979990217206693894175329255046444641219473596270869815908465388209600595.
+Reading from /dev/fibonacci at offset 461, returned the sequence 985864329041134079854737521712801814394706432953315510410398508752777354792040897021902752675861.
+Reading from /dev/fibonacci at offset 462, returned the sequence 1595161992684664972646689501703019021088600608282570556855039728226373625661856805487290962276456.
+Reading from /dev/fibonacci at offset 463, returned the sequence 2581026321725799052501427023415820835483307041235886067265438236979150980453897702509193714952317.
+Reading from /dev/fibonacci at offset 464, returned the sequence 4176188314410464025148116525118839856571907649518456624120477965205524606115754507996484677228773.
+Reading from /dev/fibonacci at offset 465, returned the sequence 6757214636136263077649543548534660692055214690754342691385916202184675586569652210505678392181090.
+Reading from /dev/fibonacci at offset 466, returned the sequence 10933402950546727102797660073653500548627122340272799315506394167390200192685406718502163069409863.
+Reading from /dev/fibonacci at offset 467, returned the sequence 17690617586682990180447203622188161240682337031027142006892310369574875779255058929007841461590953.
+Reading from /dev/fibonacci at offset 468, returned the sequence 28624020537229717283244863695841661789309459371299941322398704536965075971940465647510004531000816.
+Reading from /dev/fibonacci at offset 469, returned the sequence 46314638123912707463692067318029823029991796402327083329291014906539951751195524576517845992591769.
+Reading from /dev/fibonacci at offset 470, returned the sequence 74938658661142424746936931013871484819301255773627024651689719443505027723135990224027850523592585.
+Reading from /dev/fibonacci at offset 471, returned the sequence 121253296785055132210628998331901307849293052175954107980980734350044979474331514800545696516184354.
+Reading from /dev/fibonacci at offset 472, returned the sequence 196191955446197556957565929345772792668594307949581132632670453793550007197467505024573547039776939.
+Reading from /dev/fibonacci at offset 473, returned the sequence 317445252231252689168194927677674100517887360125535240613651188143594986671799019825119243555961293.
+Reading from /dev/fibonacci at offset 474, returned the sequence 513637207677450246125760857023446893186481668075116373246321641937144993869266524849692790595738232.
+Reading from /dev/fibonacci at offset 475, returned the sequence 831082459908702935293955784701120993704369028200651613859972830080739980541065544674812034151699525.
+Reading from /dev/fibonacci at offset 476, returned the sequence 1344719667586153181419716641724567886890850696275767987106294472017884974410332069524504824747437757.
+Reading from /dev/fibonacci at offset 477, returned the sequence 2175802127494856116713672426425688880595219724476419600966267302098624954951397614199316858899137282.
+Reading from /dev/fibonacci at offset 478, returned the sequence 3520521795081009298133389068150256767486070420752187588072561774116509929361729683723821683646575039.
+Reading from /dev/fibonacci at offset 479, returned the sequence 5696323922575865414847061494575945648081290145228607189038829076215134884313127297923138542545712321.
+Reading from /dev/fibonacci at offset 480, returned the sequence 9216845717656874712980450562726202415567360565980794777111390850331644813674856981646960226192287360.
+Reading from /dev/fibonacci at offset 481, returned the sequence 14913169640232740127827512057302148063648650711209401966150219926546779697987984279570098768737999681.
+Reading from /dev/fibonacci at offset 482, returned the sequence 24130015357889614840807962620028350479216011277190196743261610776878424511662841261217058994930287041.
+Reading from /dev/fibonacci at offset 483, returned the sequence 39043184998122354968635474677330498542864661988399598709411830703425204209650825540787157763668286722.
+Reading from /dev/fibonacci at offset 484, returned the sequence 63173200356011969809443437297358849022080673265589795452673441480303628721313666802004216758598573763.
+Reading from /dev/fibonacci at offset 485, returned the sequence 102216385354134324778078911974689347564945335253989394162085272183728832930964492342791374522266860485.
+Reading from /dev/fibonacci at offset 486, returned the sequence 165389585710146294587522349272048196587026008519579189614758713664032461652278159144795591280865434248.
+Reading from /dev/fibonacci at offset 487, returned the sequence 267605971064280619365601261246737544151971343773568583776843985847761294583242651487586965803132294733.
+Reading from /dev/fibonacci at offset 488, returned the sequence 432995556774426913953123610518785740738997352293147773391602699511793756235520810632382557083997728981.
+Reading from /dev/fibonacci at offset 489, returned the sequence 700601527838707533318724871765523284890968696066716357168446685359555050818763462119969522887130023714.
+Reading from /dev/fibonacci at offset 490, returned the sequence 1133597084613134447271848482284309025629966048359864130560049384871348807054284272752352079971127752695.
+Reading from /dev/fibonacci at offset 491, returned the sequence 1834198612451841980590573354049832310520934744426580487728496070230903857873047734872321602858257776409.
+Reading from /dev/fibonacci at offset 492, returned the sequence 2967795697064976427862421836334141336150900792786444618288545455102252664927332007624673682829385529104.
+Reading from /dev/fibonacci at offset 493, returned the sequence 4801994309516818408452995190383973646671835537213025106017041525333156522800379742496995285687643305513.
+Reading from /dev/fibonacci at offset 494, returned the sequence 7769790006581794836315417026718114982822736329999469724305586980435409187727711750121668968517028834617.
+Reading from /dev/fibonacci at offset 495, returned the sequence 12571784316098613244768412217102088629494571867212494830322628505768565710528091492618664254204672140130.
+Reading from /dev/fibonacci at offset 496, returned the sequence 20341574322680408081083829243820203612317308197211964554628215486203974898255803242740333222721700974747.
+Reading from /dev/fibonacci at offset 497, returned the sequence 32913358638779021325852241460922292241811880064424459384950843991972540608783894735358997476926373114877.
+Reading from /dev/fibonacci at offset 498, returned the sequence 53254932961459429406936070704742495854129188261636423939579059478176515507039697978099330699648074089624.
+Reading from /dev/fibonacci at offset 499, returned the sequence 86168291600238450732788312165664788095941068326060883324529903470149056115823592713458328176574447204501.
+Reading from /dev/fibonacci at offset 500, returned the sequence 139423224561697880139724382870407283950070256587697307264108962948325571622863290691557658876222521294125.
+Reading from /dev/fibonacci at offset 501, returned the sequence 225591516161936330872512695036072072046011324913758190588638866418474627738686883405015987052796968498626.
+Reading from /dev/fibonacci at offset 502, returned the sequence 365014740723634211012237077906479355996081581501455497852747829366800199361550174096573645929019489792751.
+Reading from /dev/fibonacci at offset 503, returned the sequence 590606256885570541884749772942551428042092906415213688441386695785274827100237057501589632981816458291377.
+Reading from /dev/fibonacci at offset 504, returned the sequence 955620997609204752896986850849030784038174487916669186294134525152075026461787231598163278910835948084128.
+Reading from /dev/fibonacci at offset 505, returned the sequence 1546227254494775294781736623791582212080267394331882874735521220937349853562024289099752911892652406375505.
+Reading from /dev/fibonacci at offset 506, returned the sequence 2501848252103980047678723474640612996118441882248552061029655746089424880023811520697916190803488354459633.
+Reading from /dev/fibonacci at offset 507, returned the sequence 4048075506598755342460460098432195208198709276580434935765176967026774733585835809797669102696140760835138.
+Reading from /dev/fibonacci at offset 508, returned the sequence 6549923758702735390139183573072808204317151158828986996794832713116199613609647330495585293499629115294771.
+Reading from /dev/fibonacci at offset 509, returned the sequence 10597999265301490732599643671505003412515860435409421932560009680142974347195483140293254396195769876129909.
+Reading from /dev/fibonacci at offset 510, returned the sequence 17147923024004226122738827244577811616833011594238408929354842393259173960805130470788839689695398991424680.
+Reading from /dev/fibonacci at offset 511, returned the sequence 27745922289305716855338470916082815029348872029647830861914852073402148308000613611082094085891168867554589.
+Reading from /dev/fibonacci at offset 512, returned the sequence 44893845313309942978077298160660626646181883623886239791269694466661322268805744081870933775586567858979269.
+Reading from /dev/fibonacci at offset 513, returned the sequence 72639767602615659833415769076743441675530755653534070653184546540063470576806357692953027861477736726533858.
+Reading from /dev/fibonacci at offset 514, returned the sequence 117533612915925602811493067237404068321712639277420310444454241006724792845612101774823961637064304585513127.
+Reading from /dev/fibonacci at offset 515, returned the sequence 190173380518541262644908836314147509997243394930954381097638787546788263422418459467776989498542041312046985.
+Reading from /dev/fibonacci at offset 516, returned the sequence 307706993434466865456401903551551578318956034208374691542093028553513056268030561242600951135606345897560112.
+Reading from /dev/fibonacci at offset 517, returned the sequence 497880373953008128101310739865699088316199429139329072639731816100301319690449020710377940634148387209607097.
+Reading from /dev/fibonacci at offset 518, returned the sequence 805587367387474993557712643417250666635155463347703764181824844653814375958479581952978891769754733107167209.
+Reading from /dev/fibonacci at offset 519, returned the sequence 1303467741340483121659023383282949754951354892487032836821556660754115695648928602663356832403903120316774306.
+Reading from /dev/fibonacci at offset 520, returned the sequence 2109055108727958115216736026700200421586510355834736601003381505407930071607408184616335724173657853423941515.
+Reading from /dev/fibonacci at offset 521, returned the sequence 3412522850068441236875759409983150176537865248321769437824938166162045767256336787279692556577560973740715821.
+Reading from /dev/fibonacci at offset 522, returned the sequence 5521577958796399352092495436683350598124375604156506038828319671569975838863744971896028280751218827164657336.
+Reading from /dev/fibonacci at offset 523, returned the sequence 8934100808864840588968254846666500774662240852478275476653257837732021606120081759175720837328779800905373157.
+Reading from /dev/fibonacci at offset 524, returned the sequence 14455678767661239941060750283349851372786616456634781515481577509301997444983826731071749118079998628070030493.
+Reading from /dev/fibonacci at offset 525, returned the sequence 23389779576526080530029005130016352147448857309113056992134835347034019051103908490247469955408778428975403650.
+Reading from /dev/fibonacci at offset 526, returned the sequence 37845458344187320471089755413366203520235473765747838507616412856336016496087735221319219073488777057045434143.
+Reading from /dev/fibonacci at offset 527, returned the sequence 61235237920713401001118760543382555667684331074860895499751248203370035547191643711566689028897555486020837793.
+Reading from /dev/fibonacci at offset 528, returned the sequence 99080696264900721472208515956748759187919804840608734007367661059706052043279378932885908102386332543066271936.
+Reading from /dev/fibonacci at offset 529, returned the sequence 160315934185614122473327276500131314855604135915469629507118909263076087590471022644452597131283888029087109729.
+Reading from /dev/fibonacci at offset 530, returned the sequence 259396630450514843945535792456880074043523940756078363514486570322782139633750401577338505233670220572153381665.
+Reading from /dev/fibonacci at offset 531, returned the sequence 419712564636128966418863068957011388899128076671547993021605479585858227224221424221791102364954108601240491394.
+Reading from /dev/fibonacci at offset 532, returned the sequence 679109195086643810364398861413891462942652017427626356536092049908640366857971825799129607598624329173393873059.
+Reading from /dev/fibonacci at offset 533, returned the sequence 1098821759722772776783261930370902851841780094099174349557697529494498594082193250020920709963578437774634364453.
+Reading from /dev/fibonacci at offset 534, returned the sequence 1777930954809416587147660791784794314784432111526800706093789579403138960940165075820050317562202766948028237512.
+Reading from /dev/fibonacci at offset 535, returned the sequence 2876752714532189363930922722155697166626212205625975055651487108897637555022358325840971027525781204722662601965.
+Reading from /dev/fibonacci at offset 536, returned the sequence 4654683669341605951078583513940491481410644317152775761745276688300776515962523401661021345087983971670690839477.
+Reading from /dev/fibonacci at offset 537, returned the sequence 7531436383873795315009506236096188648036856522778750817396763797198414070984881727501992372613765176393353441442.
+Reading from /dev/fibonacci at offset 538, returned the sequence 12186120053215401266088089750036680129447500839931526579142040485499190586947405129163013717701749148064044280919.
+Reading from /dev/fibonacci at offset 539, returned the sequence 19717556437089196581097595986132868777484357362710277396538804282697604657932286856665006090315514324457397722361.
+Reading from /dev/fibonacci at offset 540, returned the sequence 31903676490304597847185685736169548906931858202641803975680844768196795244879691985828019808017263472521442003280.
+Reading from /dev/fibonacci at offset 541, returned the sequence 51621232927393794428283281722302417684416215565352081372219649050894399902811978842493025898332777796978839725641.
+Reading from /dev/fibonacci at offset 542, returned the sequence 83524909417698392275468967458471966591348073767993885347900493819091195147691670828321045706350041269500281728921.
+Reading from /dev/fibonacci at offset 543, returned the sequence 135146142345092186703752249180774384275764289333345966720120142869985595050503649670814071604682819066479121454562.
+Reading from /dev/fibonacci at offset 544, returned the sequence 218671051762790578979221216639246350867112363101339852068020636689076790198195320499135117311032860335979403183483.
+Reading from /dev/fibonacci at offset 545, returned the sequence 353817194107882765682973465820020735142876652434685818788140779559062385248698970169949188915715679402458524638045.
+Reading from /dev/fibonacci at offset 546, returned the sequence 572488245870673344662194682459267086009989015536025670856161416248139175446894290669084306226748539738437927821528.
+Reading from /dev/fibonacci at offset 547, returned the sequence 926305439978556110345168148279287821152865667970711489644302195807201560695593260839033495142464219140896452459573.
+Reading from /dev/fibonacci at offset 548, returned the sequence 1498793685849229455007362830738554907162854683506737160500463612055340736142487551508117801369212758879334380281101.
+Reading from /dev/fibonacci at offset 549, returned the sequence 2425099125827785565352530979017842728315720351477448650144765807862542296838080812347151296511676978020230832740674.
+Reading from /dev/fibonacci at offset 550, returned the sequence 3923892811677015020359893809756397635478575034984185810645229419917883032980568363855269097880889736899565213021775.
+Reading from /dev/fibonacci at offset 551, returned the sequence 6348991937504800585712424788774240363794295386461634460789995227780425329818649176202420394392566714919796045762449.
+Reading from /dev/fibonacci at offset 552, returned the sequence 10272884749181815606072318598530637999272870421445820271435224647698308362799217540057689492273456451819361258784224.
+Reading from /dev/fibonacci at offset 553, returned the sequence 16621876686686616191784743387304878363067165807907454732225219875478733692617866716260109886666023166739157304546673.
+Reading from /dev/fibonacci at offset 554, returned the sequence 26894761435868431797857061985835516362340036229353275003660444523177042055417084256317799378939479618558518563330897.
+Reading from /dev/fibonacci at offset 555, returned the sequence 43516638122555047989641805373140394725407202037260729735885664398655775748034950972577909265605502785297675867877570.
+Reading from /dev/fibonacci at offset 556, returned the sequence 70411399558423479787498867358975911087747238266614004739546108921832817803452035228895708644544982403856194431208467.
+Reading from /dev/fibonacci at offset 557, returned the sequence 113928037680978527777140672732116305813154440303874734475431773320488593551486986201473617910150485189153870299086037.
+Reading from /dev/fibonacci at offset 558, returned the sequence 184339437239402007564639540091092216900901678570488739214977882242321411354939021430369326554695467593010064730294504.
+Reading from /dev/fibonacci at offset 559, returned the sequence 298267474920380535341780212823208522714056118874363473690409655562810004906426007631842944464845952782163935029380541.
+Reading from /dev/fibonacci at offset 560, returned the sequence 482606912159782542906419752914300739614957797444852212905387537805131416261365029062212271019541420375173999759675045.
+Reading from /dev/fibonacci at offset 561, returned the sequence 780874387080163078248199965737509262329013916319215686595797193367941421167791036694055215484387373157337934789055586.
+Reading from /dev/fibonacci at offset 562, returned the sequence 1263481299239945621154619718651810001943971713764067899501184731173072837429156065756267486503928793532511934548730631.
+Reading from /dev/fibonacci at offset 563, returned the sequence 2044355686320108699402819684389319264272985630083283586096981924541014258596947102450322701988316166689849869337786217.
+Reading from /dev/fibonacci at offset 564, returned the sequence 3307836985560054320557439403041129266216957343847351485598166655714087096026103168206590188492244960222361803886516848.
+Reading from /dev/fibonacci at offset 565, returned the sequence 5352192671880163019960259087430448530489942973930635071695148580255101354623050270656912890480561126912211673224303065.
+Reading from /dev/fibonacci at offset 566, returned the sequence 8660029657440217340517698490471577796706900317777986557293315235969188450649153438863503078972806087134573477110819913.
+Reading from /dev/fibonacci at offset 567, returned the sequence 14012222329320380360477957577902026327196843291708621628988463816224289805272203709520415969453367214046785150335122978.
+Reading from /dev/fibonacci at offset 568, returned the sequence 22672251986760597700995656068373604123903743609486608186281779052193478255921357148383919048426173301181358627445942891.
+Reading from /dev/fibonacci at offset 569, returned the sequence 36684474316080978061473613646275630451100586901195229815270242868417768061193560857904335017879540515228143777781065869.
+Reading from /dev/fibonacci at offset 570, returned the sequence 59356726302841575762469269714649234575004330510681838001552021920611246317114918006288254066305713816409502405227008760.
+Reading from /dev/fibonacci at offset 571, returned the sequence 96041200618922553823942883360924865026104917411877067816822264789029014378308478864192589084185254331637646183008074629.
+Reading from /dev/fibonacci at offset 572, returned the sequence 155397926921764129586412153075574099601109247922558905818374286709640260695423396870480843150490968148047148588235083389.
+Reading from /dev/fibonacci at offset 573, returned the sequence 251439127540686683410355036436498964627214165334435973635196551498669275073731875734673432234676222479684794771243158018.
+Reading from /dev/fibonacci at offset 574, returned the sequence 406837054462450812996767189512073064228323413256994879453570838208309535769155272605154275385167190627731943359478241407.
+Reading from /dev/fibonacci at offset 575, returned the sequence 658276182003137496407122225948572028855537578591430853088767389706978810842887148339827707619843413107416738130721399425.
+Reading from /dev/fibonacci at offset 576, returned the sequence 1065113236465588309403889415460645093083860991848425732542338227915288346612042420944981983005010603735148681490199640832.
+Reading from /dev/fibonacci at offset 577, returned the sequence 1723389418468725805811011641409217121939398570439856585631105617622267157454929569284809690624854016842565419620921040257.
+Reading from /dev/fibonacci at offset 578, returned the sequence 2788502654934314115214901056869862215023259562288282318173443845537555504066971990229791673629864620577714101111120681089.
+Reading from /dev/fibonacci at offset 579, returned the sequence 4511892073403039921025912698279079336962658132728138903804549463159822661521901559514601364254718637420279520732041721346.
+Reading from /dev/fibonacci at offset 580, returned the sequence 7300394728337354036240813755148941551985917695016421221977993308697378165588873549744393037884583257997993621843162402435.
+Reading from /dev/fibonacci at offset 581, returned the sequence 11812286801740393957266726453428020888948575827744560125782542771857200827110775109258994402139301895418273142575204123781.
+Reading from /dev/fibonacci at offset 582, returned the sequence 19112681530077747993507540208576962440934493522760981347760536080554578992699648659003387440023885153416266764418366526216.
+Reading from /dev/fibonacci at offset 583, returned the sequence 30924968331818141950774266662004983329883069350505541473543078852411779819810423768262381842163187048834539906993570649997.
+Reading from /dev/fibonacci at offset 584, returned the sequence 50037649861895889944281806870581945770817562873266522821303614932966358812510072427265769282187072202250806671411937176213.
+Reading from /dev/fibonacci at offset 585, returned the sequence 80962618193714031895056073532586929100700632223772064294846693785378138632320496195528151124350259251085346578405507826210.
+Reading from /dev/fibonacci at offset 586, returned the sequence 131000268055609921839337880403168874871518195097038587116150308718344497444830568622793920406537331453336153249817445002423.
+Reading from /dev/fibonacci at offset 587, returned the sequence 211962886249323953734393953935755803972218827320810651410997002503722636077151064818322071530887590704421499828222952828633.
+Reading from /dev/fibonacci at offset 588, returned the sequence 342963154304933875573731834338924678843737022417849238527147311222067133521981633441115991937424922157757653078040397831056.
+Reading from /dev/fibonacci at offset 589, returned the sequence 554926040554257829308125788274680482815955849738659889938144313725789769599132698259438063468312512862179152906263350659689.
+Reading from /dev/fibonacci at offset 590, returned the sequence 897889194859191704881857622613605161659692872156509128465291624947856903121114331700554055405737435019936805984303748490745.
+Reading from /dev/fibonacci at offset 591, returned the sequence 1452815235413449534189983410888285644475648721895169018403435938673646672720247029959992118874049947882115958890567099150434.
+Reading from /dev/fibonacci at offset 592, returned the sequence 2350704430272641239071841033501890806135341594051678146868727563621503575841361361660546174279787382902052764874870847641179.
+Reading from /dev/fibonacci at offset 593, returned the sequence 3803519665686090773261824444390176450610990315946847165272163502295150248561608391620538293153837330784168723765437946791613.
+Reading from /dev/fibonacci at offset 594, returned the sequence 6154224095958732012333665477892067256746331909998525312140891065916653824402969753281084467433624713686221488640308794432792.
+Reading from /dev/fibonacci at offset 595, returned the sequence 9957743761644822785595489922282243707357322225945372477413054568211804072964578144901622760587462044470390212405746741224405.
+Reading from /dev/fibonacci at offset 596, returned the sequence 16111967857603554797929155400174310964103654135943897789553945634128457897367547898182707228021086758156611701046055535657197.
+Reading from /dev/fibonacci at offset 597, returned the sequence 26069711619248377583524645322456554671460976361889270266967000202340261970332126043084329988608548802627001913451802276881602.
+Reading from /dev/fibonacci at offset 598, returned the sequence 42181679476851932381453800722630865635564630497833168056520945836468719867699673941267037216629635560783613614497857812538799.
+Reading from /dev/fibonacci at offset 599, returned the sequence 68251391096100309964978446045087420307025606859722438323487946038808981838031799984351367205238184363410615527949660089420401.
+Reading from /dev/fibonacci at offset 600, returned the sequence 110433070572952242346432246767718285942590237357555606380008891875277701705731473925618404421867819924194229142447517901959200.
+Reading from /dev/fibonacci at offset 601, returned the sequence 178684461669052552311410692812805706249615844217278044703496837914086683543763273909969771627106004287604844670397177991379601.
+Reading from /dev/fibonacci at offset 602, returned the sequence 289117532242004794657842939580523992192206081574833651083505729789364385249494747835588176048973824211799073812844695893338801.
+Reading from /dev/fibonacci at offset 603, returned the sequence 467801993911057346969253632393329698441821925792111695787002567703451068793258021745557947676079828499403918483241873884718402.
+Reading from /dev/fibonacci at offset 604, returned the sequence 756919526153062141627096571973853690634028007366945346870508297492815454042752769581146123725053652711202992296086569778057203.
+Reading from /dev/fibonacci at offset 605, returned the sequence 1224721520064119488596350204367183389075849933159057042657510865196266522836010791326704071401133481210606910779328443662775605.
+Reading from /dev/fibonacci at offset 606, returned the sequence 1981641046217181630223446776341037079709877940526002389528019162689081976878763560907850195126187133921809903075415013440832808.
+Reading from /dev/fibonacci at offset 607, returned the sequence 3206362566281301118819796980708220468785727873685059432185530027885348499714774352234554266527320615132416813854743457103608413.
+Reading from /dev/fibonacci at offset 608, returned the sequence 5188003612498482749043243757049257548495605814211061821713549190574430476593537913142404461653507749054226716930158470544441221.
+Reading from /dev/fibonacci at offset 609, returned the sequence 8394366178779783867863040737757478017281333687896121253899079218459778976308312265376958728180828364186643530784901927648049634.
+Reading from /dev/fibonacci at offset 610, returned the sequence 13582369791278266616906284494806735565776939502107183075612628409034209452901850178519363189834336113240870247715060398192490855.
+Reading from /dev/fibonacci at offset 611, returned the sequence 21976735970058050484769325232564213583058273190003304329511707627493988429210162443896321918015164477427513778499962325840540489.
+Reading from /dev/fibonacci at offset 612, returned the sequence 35559105761336317101675609727370949148835212692110487405124336036528197882112012622415685107849500590668384026215022724033031344.
+Reading from /dev/fibonacci at offset 613, returned the sequence 57535841731394367586444934959935162731893485882113791734636043664022186311322175066312007025864665068095897804714985049873571833.
+Reading from /dev/fibonacci at offset 614, returned the sequence 93094947492730684688120544687306111880728698574224279139760379700550384193434187688727692133714165658764281830930007773906603177.
+Reading from /dev/fibonacci at offset 615, returned the sequence 150630789224125052274565479647241274612622184456338070874396423364572570504756362755039699159578830726860179635644992823780175010.
+Reading from /dev/fibonacci at offset 616, returned the sequence 243725736716855736962686024334547386493350883030562350014156803065122954698190550443767391293292996385624461466575000597686778187.
+Reading from /dev/fibonacci at offset 617, returned the sequence 394356525940980789237251503981788661105973067486900420888553226429695525202946913198807090452871827112484641102219993421466953197.
+Reading from /dev/fibonacci at offset 618, returned the sequence 638082262657836526199937528316336047599323950517462770902710029494818479901137463642574481746164823498109102568794994019153731384.
+Reading from /dev/fibonacci at offset 619, returned the sequence 1032438788598817315437189032298124708705297018004363191791263255924514005104084376841381572199036650610593743671014987440620684581.
+Reading from /dev/fibonacci at offset 620, returned the sequence 1670521051256653841637126560614460756304620968521825962693973285419332485005221840483956053945201474108702846239809981459774415965.
+Reading from /dev/fibonacci at offset 621, returned the sequence 2702959839855471157074315592912585465009917986526189154485236541343846490109306217325337626144238124719296589910824968900395100546.
+Reading from /dev/fibonacci at offset 622, returned the sequence 4373480891112124998711442153527046221314538955048015117179209826763178975114528057809293680089439598827999436150634950360169516511.
+Reading from /dev/fibonacci at offset 623, returned the sequence 7076440730967596155785757746439631686324456941574204271664446368107025465223834275134631306233677723547296026061459919260564617057.
+Reading from /dev/fibonacci at offset 624, returned the sequence 11449921622079721154497199899966677907638995896622219388843656194870204440338362332943924986323117322375295462212094869620734133568.
+Reading from /dev/fibonacci at offset 625, returned the sequence 18526362353047317310282957646406309593963452838196423660508102562977229905562196608078556292556795045922591488273554788881298750625.
+Reading from /dev/fibonacci at offset 626, returned the sequence 29976283975127038464780157546372987501602448734818643049351758757847434345900558941022481278879912368297886950485649658502032884193.
+Reading from /dev/fibonacci at offset 627, returned the sequence 48502646328174355775063115192779297095565901573015066709859861320824664251462755549101037571436707414220478438759204447383331634818.
+Reading from /dev/fibonacci at offset 628, returned the sequence 78478930303301394239843272739152284597168350307833709759211620078672098597363314490123518850316619782518365389244854105885364519011.
+Reading from /dev/fibonacci at offset 629, returned the sequence 126981576631475750014906387931931581692734251880848776469071481399496762848826070039224556421753327196738843828004058553268696153829.
+Reading from /dev/fibonacci at offset 630, returned the sequence 205460506934777144254749660671083866289902602188682486228283101478168861446189384529348075272069946979257209217248912659154060672840.
+Reading from /dev/fibonacci at offset 631, returned the sequence 332442083566252894269656048603015447982636854069531262697354582877665624295015454568572631693823274175996053045252971212422756826669.
+Reading from /dev/fibonacci at offset 632, returned the sequence 537902590501030038524405709274099314272539456258213748925637684355834485741204839097920706965893221155253262262501883871576817499509.
+Reading from /dev/fibonacci at offset 633, returned the sequence 870344674067282932794061757877114762255176310327745011622992267233500110036220293666493338659716495331249315307754855083999574326178.
+Reading from /dev/fibonacci at offset 634, returned the sequence 1408247264568312971318467467151214076527715766585958760548629951589334595777425132764414045625609716486502577570256738955576391825687.
+Reading from /dev/fibonacci at offset 635, returned the sequence 2278591938635595904112529225028328838782892076913703772171622218822834705813645426430907384285326211817751892878011594039575966151865.
+Reading from /dev/fibonacci at offset 636, returned the sequence 3686839203203908875430996692179542915310607843499662532720252170412169301591070559195321429910935928304254470448268332995152357977552.
+Reading from /dev/fibonacci at offset 637, returned the sequence 5965431141839504779543525917207871754093499920413366304891874389235004007404715985626228814196262140122006363326279927034728324129417.
+Reading from /dev/fibonacci at offset 638, returned the sequence 9652270345043413654974522609387414669404107763913028837612126559647173308995786544821550244107198068426260833774548260029880682106969.
+Reading from /dev/fibonacci at offset 639, returned the sequence 15617701486882918434518048526595286423497607684326395142504000948882177316400502530447779058303460208548267197100828187064609006236386.
+Reading from /dev/fibonacci at offset 640, returned the sequence 25269971831926332089492571135982701092901715448239423980116127508529350625396289075269329302410658276974528030875376447094489688343355.
+Reading from /dev/fibonacci at offset 641, returned the sequence 40887673318809250524010619662577987516399323132565819122620128457411527941796791605717108360714118485522795227976204634159098694579741.
+Reading from /dev/fibonacci at offset 642, returned the sequence 66157645150735582613503190798560688609301038580805243102736255965940878567193080680986437663124776762497323258851581081253588382923096.
+Reading from /dev/fibonacci at offset 643, returned the sequence 107045318469544833137513810461138676125700361713371062225356384423352406508989872286703546023838895248020118486827785715412687077502837.
+Reading from /dev/fibonacci at offset 644, returned the sequence 173202963620280415751017001259699364735001400294176305328092640389293285076182952967689983686963672010517441745679366796666275460425933.
+Reading from /dev/fibonacci at offset 645, returned the sequence 280248282089825248888530811720838040860701762007547367553449024812645691585172825254393529710802567258537560232507152512078962537928770.
+Reading from /dev/fibonacci at offset 646, returned the sequence 453451245710105664639547812980537405595703162301723672881541665201938976661355778222083513397766239269055001978186519308745237998354703.
+Reading from /dev/fibonacci at offset 647, returned the sequence 733699527799930913528078624701375446456404924309271040434990690014584668246528603476477043108568806527592562210693671820824200536283473.
+Reading from /dev/fibonacci at offset 648, returned the sequence 1187150773510036578167626437681912852052108086610994713316532355216523644907884381698560556506335045796647564188880191129569438534638176.
+Reading from /dev/fibonacci at offset 649, returned the sequence 1920850301309967491695705062383288298508513010920265753751523045231108313154412985175037599614903852324240126399573862950393639070921649.
+Reading from /dev/fibonacci at offset 650, returned the sequence 3108001074820004069863331500065201150560621097531260467068055400447631958062297366873598156121238898120887690588454054079963077605559825.
+Reading from /dev/fibonacci at offset 651, returned the sequence 5028851376129971561559036562448489449069134108451526220819578445678740271216710352048635755736142750445127816988027917030356716676481474.
+Reading from /dev/fibonacci at offset 652, returned the sequence 8136852450949975631422368062513690599629755205982786687887633846126372229279007718922233911857381648566015507576481971110319794282041299.
+Reading from /dev/fibonacci at offset 653, returned the sequence 13165703827079947192981404624962180048698889314434312908707212291805112500495718070970869667593524399011143324564509888140676510958522773.
+Reading from /dev/fibonacci at offset 654, returned the sequence 21302556278029922824403772687475870648328644520417099596594846137931484729774725789893103579450906047577158832140991859250996305240564072.
+Reading from /dev/fibonacci at offset 655, returned the sequence 34468260105109870017385177312438050697027533834851412505302058429736597230270443860863973247044430446588302156705501747391672816199086845.
+Reading from /dev/fibonacci at offset 656, returned the sequence 55770816383139792841788949999913921345356178355268512101896904567668081960045169650757076826495336494165460988846493606642669121439650917.
+Reading from /dev/fibonacci at offset 657, returned the sequence 90239076488249662859174127312351972042383712190119924607198962997404679190315613511621050073539766940753763145551995354034341937638737762.
+Reading from /dev/fibonacci at offset 658, returned the sequence 146009892871389455700963077312265893387739890545388436709095867565072761150360783162378126900035103434919224134398488960677011059078388679.
+Reading from /dev/fibonacci at offset 659, returned the sequence 236248969359639118560137204624617865430123602735508361316294830562477440340676396673999176973574870375672987279950484314711352996717126441.
+Reading from /dev/fibonacci at offset 660, returned the sequence 382258862231028574261100281936883758817863493280896798025390698127550201491037179836377303873609973810592211414348973275388364055795515120.
+Reading from /dev/fibonacci at offset 661, returned the sequence 618507831590667692821237486561501624247987096016405159341685528690027641831713576510376480847184844186265198694299457590099717052512641561.
+Reading from /dev/fibonacci at offset 662, returned the sequence 1000766693821696267082337768498385383065850589297301957367076226817577843322750756346753784720794817996857410108648430865488081108308156681.
+Reading from /dev/fibonacci at offset 663, returned the sequence 1619274525412363959903575255059887007313837685313707116708761755507605485154464332857130265567979662183122608802947888455587798160820798242.
+Reading from /dev/fibonacci at offset 664, returned the sequence 2620041219234060226985913023558272390379688274611009074075837982325183328477215089203884050288774480179980018911596319321075879269128954923.
+Reading from /dev/fibonacci at offset 665, returned the sequence 4239315744646424186889488278618159397693525959924716190784599737832788813631679422061014315856754142363102627714544207776663677429949753165.
+Reading from /dev/fibonacci at offset 666, returned the sequence 6859356963880484413875401302176431788073214234535725264860437720157972142108894511264898366145528622543082646626140527097739556699078708088.
+Reading from /dev/fibonacci at offset 667, returned the sequence 11098672708526908600764889580794591185766740194460441455645037457990760955740573933325912682002282764906185274340684734874403234129028461253.
+Reading from /dev/fibonacci at offset 668, returned the sequence 17958029672407393014640290882971022973839954428996166720505475178148733097849468444590811048147811387449267920966825261972142790828107169341.
+Reading from /dev/fibonacci at offset 669, returned the sequence 29056702380934301615405180463765614159606694623456608176150512636139494053590042377916723730150094152355453195307509996846546024957135630594.
+Reading from /dev/fibonacci at offset 670, returned the sequence 47014732053341694630045471346736637133446649052452774896655987814288227151439510822507534778297905539804721116274335258818688815785242799935.
+Reading from /dev/fibonacci at offset 671, returned the sequence 76071434434275996245450651810502251293053343675909383072806500450427721205029553200424258508447999692160174311581845255665234840742378430529.
+Reading from /dev/fibonacci at offset 672, returned the sequence 123086166487617690875496123157238888426499992728362157969462488264715948356469064022931793286745905231964895427856180514483923656527621230464.
+Reading from /dev/fibonacci at offset 673, returned the sequence 199157600921893687120946774967741139719553336404271541042268988715143669561498617223356051795193904924125069739438025770149158497269999660993.
+Reading from /dev/fibonacci at offset 674, returned the sequence 322243767409511377996442898124980028146053329132633699011731476979859617917967681246287845081939810156089965167294206284633082153797620891457.
+Reading from /dev/fibonacci at offset 675, returned the sequence 521401368331405065117389673092721167865606665536905240054000465695003287479466298469643896877133715080215034906732232054782240651067620552450.
+Reading from /dev/fibonacci at offset 676, returned the sequence 843645135740916443113832571217701196011659994669538939065731942674862905397433979715931741959073525236305000074026438339415322804865241443907.
+Reading from /dev/fibonacci at offset 677, returned the sequence 1365046504072321508231222244310422363877266660206444179119732408369866192876900278185575638836207240316520034980758670394197563455932861996357.
+Reading from /dev/fibonacci at offset 678, returned the sequence 2208691639813237951345054815528123559888926654875983118185464351044729098274334257901507380795280765552825035054785108733612886260798103440264.
+Reading from /dev/fibonacci at offset 679, returned the sequence 3573738143885559459576277059838545923766193315082427297305196759414595291151234536087083019631488005869345070035543779127810449716730965436621.
+Reading from /dev/fibonacci at offset 680, returned the sequence 5782429783698797410921331875366669483655119969958410415490661110459324389425568793988590400426768771422170105090328887861423335977529068876885.
+Reading from /dev/fibonacci at offset 681, returned the sequence 9356167927584356870497608935205215407421313285040837712795857869873919680576803330075673420058256777291515175125872666989233785694260034313506.
+Reading from /dev/fibonacci at offset 682, returned the sequence 15138597711283154281418940810571884891076433254999248128286518980333244070002372124064263820485025548713685280216201554850657121671789103190391.
+Reading from /dev/fibonacci at offset 683, returned the sequence 24494765638867511151916549745777100298497746540040085841082376850207163750579175454139937240543282326005200455342074221839890907366049137503897.
+Reading from /dev/fibonacci at offset 684, returned the sequence 39633363350150665433335490556348985189574179795039333969368895830540407820581547578204201061028307874718885735558275776690548029037838240694288.
+Reading from /dev/fibonacci at offset 685, returned the sequence 64128128989018176585252040302126085488071926335079419810451272680747571571160723032344138301571590200724086190900349998530438936403887378198185.
+Reading from /dev/fibonacci at offset 686, returned the sequence 103761492339168842018587530858475070677646106130118753779820168511287979391742270610548339362599898075442971926458625775220986965441725618892473.
+Reading from /dev/fibonacci at offset 687, returned the sequence 167889621328187018603839571160601156165718032465198173590271441192035550962902993642892477664171488276167058117358975773751425901845612997090658.
+Reading from /dev/fibonacci at offset 688, returned the sequence 271651113667355860622427102019076226843364138595316927370091609703323530354645264253440817026771386351610030043817601548972412867287338615983131.
+Reading from /dev/fibonacci at offset 689, returned the sequence 439540734995542879226266673179677383009082171060515100960363050895359081317548257896333294690942874627777088161176577322723838769132951613073789.
+Reading from /dev/fibonacci at offset 690, returned the sequence 711191848662898739848693775198753609852446309655832028330454660598682611672193522149774111717714260979387118204994178871696251636420290229056920.
+Reading from /dev/fibonacci at offset 691, returned the sequence 1150732583658441619074960448378430992861528480716347129290817711494041692989741780046107406408657135607164206366170756194420090405553241842130709.
+Reading from /dev/fibonacci at offset 692, returned the sequence 1861924432321340358923654223577184602713974790372179157621272372092724304661935302195881518126371396586551324571164935066116342041973532071187629.
+Reading from /dev/fibonacci at offset 693, returned the sequence 3012657015979781977998614671955615595575503271088526286912090083586765997651677082241988924535028532193715530937335691260536432447526773913318338.
+Reading from /dev/fibonacci at offset 694, returned the sequence 4874581448301122336922268895532800198289478061460705444533362455679490302313612384437870442661399928780266855508500626326652774489500305984505967.
+Reading from /dev/fibonacci at offset 695, returned the sequence 7887238464280904314920883567488415793864981332549231731445452539266256299965289466679859367196428460973982386445836317587189206937027079897824305.
+Reading from /dev/fibonacci at offset 696, returned the sequence 12761819912582026651843152463021215992154459394009937175978814994945746602278901851117729809857828389754249241954336943913841981426527385882330272.
+Reading from /dev/fibonacci at offset 697, returned the sequence 20649058376862930966764036030509631786019440726559168907424267534212002902244191317797589177054256850728231628400173261501031188363554465780154577.
+Reading from /dev/fibonacci at offset 698, returned the sequence 33410878289444957618607188493530847778173900120569106083403082529157749504523093168915318986912085240482480870354510205414873169790081851662484849.
+Reading from /dev/fibonacci at offset 699, returned the sequence 54059936666307888585371224524040479564193340847128274990827350063369752406767284486712908163966342091210712498754683466915904358153636317442639426.
+Reading from /dev/fibonacci at offset 700, returned the sequence 87470814955752846203978413017571327342367240967697381074230432592527501911290377655628227150878427331693193369109193672330777527943718169105124275.
+Reading from /dev/fibonacci at offset 701, returned the sequence 141530751622060734789349637541611806906560581814825656065057782655897254318057662142341135314844769422903905867863877139246681886097354486547763701.
+Reading from /dev/fibonacci at offset 702, returned the sequence 229001566577813580993328050559183134248927822782523037139288215248424756229348039797969362465723196754597099236973070811577459414041072655652887976.
+Reading from /dev/fibonacci at offset 703, returned the sequence 370532318199874315782677688100794941155488404597348693204345997904322010547405701940310497780567966177501005104836947950824141300138427142200651677.
+Reading from /dev/fibonacci at offset 704, returned the sequence 599533884777687896776005738659978075404416227379871730343634213152746766776753741738279860246291162932098104341810018762401600714179499797853539653.
+Reading from /dev/fibonacci at offset 705, returned the sequence 970066202977562212558683426760773016559904631977220423547980211057068777324159443678590358026859129109599109446646966713225742014317926940054191330.
+Reading from /dev/fibonacci at offset 706, returned the sequence 1569600087755250109334689165420751091964320859357092153891614424209815544100913185416870218273150292041697213788456985475627342728497426737907730983.
+Reading from /dev/fibonacci at offset 707, returned the sequence 2539666290732812321893372592181524108524225491334312577439594635266884321425072629095460576300009421151296323235103952188853084742815353677961922313.
+Reading from /dev/fibonacci at offset 708, returned the sequence 4109266378488062431228061757602275200488546350691404731331209059476699865525985814512330794573159713192993537023560937664480427471312780415869653296.
+Reading from /dev/fibonacci at offset 709, returned the sequence 6648932669220874753121434349783799309012771842025717308770803694743584186951058443607791370873169134344289860258664889853333512214128134093831575609.
+Reading from /dev/fibonacci at offset 710, returned the sequence 10758199047708937184349496107386074509501318192717122040102012754220284052477044258120122165446328847537283397282225827517813939685440914509701228905.
+Reading from /dev/fibonacci at offset 711, returned the sequence 17407131716929811937470930457169873818514090034742839348872816448963868239428102701727913536319497981881573257540890717371147451899569048603532804514.
+Reading from /dev/fibonacci at offset 712, returned the sequence 28165330764638749121820426564555948328015408227459961388974829203184152291905146959848035701765826829418856654823116544888961391585009963113234033419.
+Reading from /dev/fibonacci at offset 713, returned the sequence 45572462481568561059291357021725822146529498262202800737847645652148020531333249661575949238085324811300429912364007262260108843484579011716766837933.
+Reading from /dev/fibonacci at offset 714, returned the sequence 73737793246207310181111783586281770474544906489662762126822474855332172823238396621423984939851151640719286567187123807149070235069588974830000871352.
+Reading from /dev/fibonacci at offset 715, returned the sequence 119310255727775871240403140608007592621074404751865562864670120507480193354571646282999934177936476452019716479551131069409179078554167986546767709285.
+Reading from /dev/fibonacci at offset 716, returned the sequence 193048048973983181421514924194289363095619311241528324991492595362812366177810042904423919117787628092739003046738254876558249313623756961376768580637.
+Reading from /dev/fibonacci at offset 717, returned the sequence 312358304701759052661918064802296955716693715993393887856162715870292559532381689187423853295724104544758719526289385945967428392177924947923536289922.
+Reading from /dev/fibonacci at offset 718, returned the sequence 505406353675742234083432988996586318812313027234922212847655311233104925710191732091847772413511732637497722573027640822525677705801681909300304870559.
+Reading from /dev/fibonacci at offset 719, returned the sequence 817764658377501286745351053798883274529006743228316100703818027103397485242573421279271625709235837182256442099317026768493106097979606857223841160481.
+Reading from /dev/fibonacci at offset 720, returned the sequence 1323171012053243520828784042795469593341319770463238313551473338336502410952765153371119398122747569819754164672344667591018783803781288766524146031040.
+Reading from /dev/fibonacci at offset 721, returned the sequence 2140935670430744807574135096594352867870326513691554414255291365439899896195338574650391023831983407002010606771661694359511889901760895623747987191521.
+Reading from /dev/fibonacci at offset 722, returned the sequence 3464106682483988328402919139389822461211646284154792727806764703776402307148103728021510421954730976821764771444006361950530673705542184390272133222561.
+Reading from /dev/fibonacci at offset 723, returned the sequence 5605042352914733135977054235984175329081972797846347142062056069216302203343442302671901445786714383823775378215668056310042563607303080014020120414082.
+Reading from /dev/fibonacci at offset 724, returned the sequence 9069149035398721464379973375373997790293619082001139869868820772992704510491546030693411867741445360645540149659674418260573237312845264404292253636643.
+Reading from /dev/fibonacci at offset 725, returned the sequence 14674191388313454600357027611358173119375591879847487011930876842209006713834988333365313313528159744469315527875342474570615800920148344418312374050725.
+Reading from /dev/fibonacci at offset 726, returned the sequence 23743340423712176064737000986732170909669210961848626881799697615201711224326534364058725181269605105114855677535016892831189038232993608822604627687368.
+Reading from /dev/fibonacci at offset 727, returned the sequence 38417531812025630665094028598090344029044802841696113893730574457410717938161522697424038494797764849584171205410359367401804839153141953240917001738093.
+Reading from /dev/fibonacci at offset 728, returned the sequence 62160872235737806729831029584822514938714013803544740775530272072612429162488057061482763676067369954699026882945376260232993877386135562063521629425461.
+Reading from /dev/fibonacci at offset 729, returned the sequence 100578404047763437394925058182912858967758816645240854669260846530023147100649579758906802170865134804283198088355735627634798716539277515304438631163554.
+Reading from /dev/fibonacci at offset 730, returned the sequence 162739276283501244124756087767735373906472830448785595444791118602635576263137636820389565846932504758982224971301111887867792593925413077367960260589015.
+Reading from /dev/fibonacci at offset 731, returned the sequence 263317680331264681519681145950648232874231647094026450114051965132658723363787216579296368017797639563265423059656847515502591310464690592672398891752569.
+Reading from /dev/fibonacci at offset 732, returned the sequence 426056956614765925644437233718383606780704477542812045558843083735294299626924853399685933864730144322247648030957959403370383904390103670040359152341584.
+Reading from /dev/fibonacci at offset 733, returned the sequence 689374636946030607164118379669031839654936124636838495672895048867953022990712069978982301882527783885513071090614806918872975214854794262712758044094153.
+Reading from /dev/fibonacci at offset 734, returned the sequence 1115431593560796532808555613387415446435640602179650541231738132603247322617636923378668235747257928207760719121572766322243359119244897932753117196435737.
+Reading from /dev/fibonacci at offset 735, returned the sequence 1804806230506827139972673993056447286090576726816489036904633181471200345608348993357650537629785712093273790212187573241116334334099692195465875240529890.
+Reading from /dev/fibonacci at offset 736, returned the sequence 2920237824067623672781229606443862732526217328996139578136371314074447668225985916736318773377043640301034509333760339563359693453344590128218992436965627.
+Reading from /dev/fibonacci at offset 737, returned the sequence 4725044054574450812753903599500310018616794055812628615041004495545648013834334910093969311006829352394308299545947912804476027787444282323684867677495517.
+Reading from /dev/fibonacci at offset 738, returned the sequence 7645281878642074485535133205944172751143011384808768193177375809620095682060320826830288084383872992695342808879708252367835721240788872451903860114461144.
+Reading from /dev/fibonacci at offset 739, returned the sequence 12370325933216525298289036805444482769759805440621396808218380305165743695894655736924257395390702345089651108425656165172311749028233154775588727791956661.
+Reading from /dev/fibonacci at offset 740, returned the sequence 20015607811858599783824170011388655520902816825430165001395756114785839377954976563754545479774575337784993917305364417540147470269022027227492587906417805.
+Reading from /dev/fibonacci at offset 741, returned the sequence 32385933745075125082113206816833138290662622266051561809614136419951583073849632300678802875165277682874645025731020582712459219297255182003081315698374466.
+Reading from /dev/fibonacci at offset 742, returned the sequence 52401541556933724865937376828221793811565439091481726811009892534737422451804608864433348354939853020659638943036385000252606689566277209230573903604792271.
+Reading from /dev/fibonacci at offset 743, returned the sequence 84787475302008849948050583645054932102228061357533288620624028954689005525654241165112151230105130703534283968767405582965065908863532391233655219303166737.
+Reading from /dev/fibonacci at offset 744, returned the sequence 137189016858942574813987960473276725913793500449015015431633921489426427977458850029545499585044983724193922911803790583217672598429809600464229122907959008.
+Reading from /dev/fibonacci at offset 745, returned the sequence 221976492160951424762038544118331658016021561806548304052257950444115433503113091194657650815150114427728206880571196166182738507293341991697884342211125745.
+Reading from /dev/fibonacci at offset 746, returned the sequence 359165509019893999576026504591608383929815062255563319483891871933541861480571941224203150400195098151922129792374986749400411105723151592162113465119084753.
+Reading from /dev/fibonacci at offset 747, returned the sequence 581142001180845424338065048709940041945836624062111623536149822377657294983685032418860801215345212579650336672946182915583149613016493583859997807330210498.
+Reading from /dev/fibonacci at offset 748, returned the sequence 940307510200739423914091553301548425875651686317674943020041694311199156464256973643063951615540310731572466465321169664983560718739645176022111272449295251.
+Reading from /dev/fibonacci at offset 749, returned the sequence 1521449511381584848252156602011488467821488310379786566556191516688856451447942006061924752830885523311222803138267352580566710331756138759882109079779505749.
+Reading from /dev/fibonacci at offset 750, returned the sequence 2461757021582324272166248155313036893697139996697461509576233211000055607912198979704988704446425834042795269603588522245550271050495783935904220352228801000.
+Reading from /dev/fibonacci at offset 751, returned the sequence 3983206532963909120418404757324525361518628307077248076132424727688912059360140985766913457277311357354018072741855874826116981382251922695786329432008306749.
+Reading from /dev/fibonacci at offset 752, returned the sequence 6444963554546233392584652912637562255215768303774709585708657938688967667272339965471902161723737191396813342345444397071667252432747706631690549784237107749.
+Reading from /dev/fibonacci at offset 753, returned the sequence 10428170087510142513003057669962087616734396610851957661841082666377879726632480951238815619001048548750831415087300271897784233814999629327476879216245414498.
+Reading from /dev/fibonacci at offset 754, returned the sequence 16873133642056375905587710582599649871950164914626667247549740605066847393904820916710717780724785740147644757432744668969451486247747335959167429000482522247.
+Reading from /dev/fibonacci at offset 755, returned the sequence 27301303729566518418590768252561737488684561525478624909390823271444727120537301867949533399725834288898476172520044940867235720062746965286644308216727936745.
+Reading from /dev/fibonacci at offset 756, returned the sequence 44174437371622894324178478835161387360634726440105292156940563876511574514442122784660251180450620029046120929952789609836687206310494301245811737217210458992.
+Reading from /dev/fibonacci at offset 757, returned the sequence 71475741101189412742769247087723124849319287965583917066331387147956301634979424652609784580176454317944597102472834550703922926373241266532456045433938395737.
+Reading from /dev/fibonacci at offset 758, returned the sequence 115650178472812307066947725922884512209954014405689209223271951024467876149421547437270035760627074346990718032425624160540610132683735567778267782651148854729.
+Reading from /dev/fibonacci at offset 759, returned the sequence 187125919574001719809716973010607637059273302371273126289603338172424177784400972089879820340803528664935315134898458711244533059056976834310723828085087250466.
+Reading from /dev/fibonacci at offset 760, returned the sequence 302776098046814026876664698933492149269227316776962335512875289196892053933822519527149856101430603011926033167324082871785143191740712402088991610736236105195.
+Reading from /dev/fibonacci at offset 761, returned the sequence 489902017620815746686381671944099786328500619148235461802478627369316231718223491617029676442234131676861348302222541583029676250797689236399715438821323355661.
+Reading from /dev/fibonacci at offset 762, returned the sequence 792678115667629773563046370877591935597727935925197797315353916566208285652046011144179532543664734688787381469546624454814819442538401638488707049557559460856.
+Reading from /dev/fibonacci at offset 763, returned the sequence 1282580133288445520249428042821691721926228555073433259117832543935524517370269502761209208985898866365648729771769166037844495693336090874888422488378882816517.
+Reading from /dev/fibonacci at offset 764, returned the sequence 2075258248956075293812474413699283657523956490998631056433186460501732803022315513905388741529563601054436111241315790492659315135874492513377129537936442277373.
+Reading from /dev/fibonacci at offset 765, returned the sequence 3357838382244520814061902456520975379450185046072064315551019004437257320392585016666597950515462467420084841013084956530503810829210583388265552026315325093890.
+Reading from /dev/fibonacci at offset 766, returned the sequence 5433096631200596107874376870220259036974141537070695371984205464938990123414900530571986692045026068474520952254400747023163125965085075901642681564251767371263.
+Reading from /dev/fibonacci at offset 767, returned the sequence 8790935013445116921936279326741234416424326583142759687535224469376247443807485547238584642560488535894605793267485703553666936794295659289908233590567092465153.
+Reading from /dev/fibonacci at offset 768, returned the sequence 14224031644645713029810656196961493453398468120213455059519429934315237567222386077810571334605514604369126745521886450576830062759380735191550915154818859836416.
+Reading from /dev/fibonacci at offset 769, returned the sequence 23014966658090829951746935523702727869822794703356214747054654403691485011029871625049155977166003140263732538789372154130496999553676394481459148745385952301569.
+Reading from /dev/fibonacci at offset 770, returned the sequence 37238998302736542981557591720664221323221262823569669806574084338006722578252257702859727311771517744632859284311258604707327062313057129673010063900204812137985.
+Reading from /dev/fibonacci at offset 771, returned the sequence 60253964960827372933304527244366949193044057526925884553628738741698207589282129327908883288937520884896591823100630758837824061866733524154469212645590764439554.
+Reading from /dev/fibonacci at offset 772, returned the sequence 97492963263563915914862118965031170516265320350495554360202823079704930167534387030768610600709038629529451107411889363545151124179790653827479276545795576577539.
+Reading from /dev/fibonacci at offset 773, returned the sequence 157746928224391288848166646209398119709309377877421438913831561821403137756816516358677493889646559514426042930512520122382975186046524177981948489191386341017093.
+Reading from /dev/fibonacci at offset 774, returned the sequence 255239891487955204763028765174429290225574698227916993274034384901108067924350903389446104490355598143955494037924409485928126310226314831809427765737181917594632.
+Reading from /dev/fibonacci at offset 775, returned the sequence 412986819712346493611195411383827409934884076105338432187865946722511205681167419748123598380002157658381536968436929608311101496272839009791376254928568258611725.
+Reading from /dev/fibonacci at offset 776, returned the sequence 668226711200301698374224176558256700160458774333255425461900331623619273605518323137569702870357755802337031006361339094239227806499153841600804020665750176206357.
+Reading from /dev/fibonacci at offset 777, returned the sequence 1081213530912648191985419587942084110095342850438593857649766278346130479286685742885693301250359913460718567974798268702550329302771992851392180275594318434818082.
+Reading from /dev/fibonacci at offset 778, returned the sequence 1749440242112949890359643764500340810255801624771849283111666609969749752892204066023263004120717669263055598981159607796789557109271146692992984296260068611024439.
+Reading from /dev/fibonacci at offset 779, returned the sequence 2830653773025598082345063352442424920351144475210443140761432888315880232178889808908956305371077582723774166955957876499339886412043139544385164571854387045842521.
+Reading from /dev/fibonacci at offset 780, returned the sequence 4580094015138547972704707116942765730606946099982292423873099498285629985071093874932219309491795251986829765937117484296129443521314286237378148868114455656866960.
+Reading from /dev/fibonacci at offset 781, returned the sequence 7410747788164146055049770469385190650958090575192735564634532386601510217249983683841175614862872834710603932893075360795469329933357425781763313439968842702709481.
+Reading from /dev/fibonacci at offset 782, returned the sequence 11990841803302694027754477586327956381565036675175027988507631884887140202321077558773394924354668086697433698830192845091598773454671712019141462308083298359576441.
+Reading from /dev/fibonacci at offset 783, returned the sequence 19401589591466840082804248055713147032523127250367763553142164271488650419571061242614570539217540921408037631723268205887068103388029137800904775748052141062285922.
+Reading from /dev/fibonacci at offset 784, returned the sequence 31392431394769534110558725642041103414088163925542791541649796156375790621892138801387965463572209008105471330553461050978666876842700849820046238056135439421862363.
+Reading from /dev/fibonacci at offset 785, returned the sequence 50794020986236374193362973697754250446611291175910555094791960427864441041463200044002536002789749929513508962276729256865734980230729987620951013804187580484148285.
+Reading from /dev/fibonacci at offset 786, returned the sequence 82186452381005908303921699339795353860699455101453346636441756584240231663355338845390501466361958937618980292830190307844401857073430837440997251860323019906010648.
+Reading from /dev/fibonacci at offset 787, returned the sequence 132980473367242282497284673037549604307310746277363901731233717012104672704818538889393037469151708867132489255106919564710136837304160825061948265664510600390158933.
+Reading from /dev/fibonacci at offset 788, returned the sequence 215166925748248190801206372377344958168010201378817248367675473596344904368173877734783538935513667804751469547937109872554538694377591662502945517524833620296169581.
+Reading from /dev/fibonacci at offset 789, returned the sequence 348147399115490473298491045414894562475320947656181150098909190608449577072992416624176576404665376671883958803044029437264675531681752487564893783189344220686328514.
+Reading from /dev/fibonacci at offset 790, returned the sequence 563314324863738664099697417792239520643331149034998398466584664204794481441166294358960115340179044476635428350981139309819214226059344150067839300714177840982498095.
+Reading from /dev/fibonacci at offset 791, returned the sequence 911461723979229137398188463207134083118652096691179548565493854813244058514158710983136691744844421148519387154025168747083889757741096637632733083903522061668826609.
+Reading from /dev/fibonacci at offset 792, returned the sequence 1474776048842967801497885880999373603761983245726177947032078519018038539955325005342096807085023465625154815505006308056903103983800440787700572384617699902651324704.
+Reading from /dev/fibonacci at offset 793, returned the sequence 2386237772822196938896074344206507686880635342417357495597572373831282598469483716325233498829867886773674202659031476803986993741541537425333305468521221964320151313.
+Reading from /dev/fibonacci at offset 794, returned the sequence 3861013821665164740393960225205881290642618588143535442629650892849321138424808721667330305914891352398829018164037784860890097725341978213033877853138921866971476017.
+Reading from /dev/fibonacci at offset 795, returned the sequence 6247251594487361679290034569412388977523253930560892938227223266680603736894292437992563804744759239172503220823069261664877091466883515638367183321660143831291627330.
+Reading from /dev/fibonacci at offset 796, returned the sequence 10108265416152526419683994794618270268165872518704428380856874159529924875319101159659894110659650591571332238987107046525767189192225493851401061174799065698263103347.
+Reading from /dev/fibonacci at offset 797, returned the sequence 16355517010639888098974029364030659245689126449265321319084097426210528612213393597652457915404409830743835459810176308190644280659109009489768244496459209529554730677.
+Reading from /dev/fibonacci at offset 798, returned the sequence 26463782426792414518658024158648929513854998967969749699940971585740453487532494757312352026064060422315167698797283354716411469851334503341169305671258275227817834024.
+Reading from /dev/fibonacci at offset 799, returned the sequence 42819299437432302617632053522679588759544125417235071019025069011950982099745888354964809941468470253059003158607459662907055750510443512830937550167717484757372564701.
+Reading from /dev/fibonacci at offset 800, returned the sequence 69283081864224717136290077681328518273399124385204820718966040597691435587278383112277161967532530675374170857404743017623467220361778016172106855838975759985190398725.
+Reading from /dev/fibonacci at offset 801, returned the sequence 112102381301657019753922131204008107032943249802439891737991109609642417687024271467241971909001000928433174016012202680530522970872221529003044406006693244742562963426.
+Reading from /dev/fibonacci at offset 802, returned the sequence 181385463165881736890212208885336625306342374187644712456957150207333853274302654579519133876533531603807344873416945698153990191233999545175151261845669004727753362151.
+Reading from /dev/fibonacci at offset 803, returned the sequence 293487844467538756644134340089344732339285623990084604194948259816976270961326926046761105785534532532240518889429148378684513162106221074178195667852362249470316325577.
+Reading from /dev/fibonacci at offset 804, returned the sequence 474873307633420493534346548974681357645627998177729316651905410024310124235629580626280239662068064136047863762846094076838503353340220619353346929698031254198069687728.
+Reading from /dev/fibonacci at offset 805, returned the sequence 768361152100959250178480889064026089984913622167813920846853669841286395196956506673041345447602596668288382652275242455523016515446441693531542597550393503668386013305.
+Reading from /dev/fibonacci at offset 806, returned the sequence 1243234459734379743712827438038707447630541620345543237498759079865596519432586087299321585109670660804336246415121336532361519868786662312884889527248424757866455701033.
+Reading from /dev/fibonacci at offset 807, returned the sequence 2011595611835338993891308327102733537615455242513357158345612749706882914629542593972362930557273257472624629067396578987884536384233104006416432124798818261534841714338.
+Reading from /dev/fibonacci at offset 808, returned the sequence 3254830071569718737604135765141440985245996862858900395844371829572479434062128681271684515666943918276960875482517915520246056253019766319301321652047243019401297415371.
+Reading from /dev/fibonacci at offset 809, returned the sequence 5266425683405057731495444092244174522861452105372257554189984579279362348691671275244047446224217175749585504549914494508130592637252870325717753776846061280936139129709.
+Reading from /dev/fibonacci at offset 810, returned the sequence 8521255754974776469099579857385615508107448968231157950034356408851841782753799956515731961891161094026546380032432410028376648890272636645019075428893304300337436545080.
+Reading from /dev/fibonacci at offset 811, returned the sequence 13787681438379834200595023949629790030968901073603415504224340988131204131445471231759779408115378269776131884582346904536507241527525506970736829205739365581273575674789.
+Reading from /dev/fibonacci at offset 812, returned the sequence 22308937193354610669694603807015405539076350041834573454258697396983045914199271188275511370006539363802678264614779314564883890417798143615755904634632669881611012219869.
+Reading from /dev/fibonacci at offset 813, returned the sequence 36096618631734444870289627756645195570045251115437988958483038385114250045644742420035290778121917633578810149197126219101391131945323650586492733840372035462884587894658.
+Reading from /dev/fibonacci at offset 814, returned the sequence 58405555825089055539984231563660601109121601157272562412741735782097295959844013608310802148128456997381488413811905533666275022363121794202248638475004705344495600114527.
+Reading from /dev/fibonacci at offset 815, returned the sequence 94502174456823500410273859320305796679166852272710551371224774167211546005488756028346092926250374630960298563009031752767666154308445444788741372315376740807380188009185.
+Reading from /dev/fibonacci at offset 816, returned the sequence 152907730281912555950258090883966397788288453429983113783966509949308841965332769636656895074378831628341786976820937286433941176671567238990990010790381446151875788123712.
+Reading from /dev/fibonacci at offset 817, returned the sequence 247409904738736056360531950204272194467455305702693665155191284116520387970821525665002988000629206259302085539829969039201607330980012683779731383105758186959255976132897.
+Reading from /dev/fibonacci at offset 818, returned the sequence 400317635020648612310790041088238592255743759132676778939157794065829229936154295301659883075008037887643872516650906325635548507651579922770721393896139633111131764256609.
+Reading from /dev/fibonacci at offset 819, returned the sequence 647727539759384668671321991292510786723199064835370444094349078182349617906975820966662871075637244146945958056480875364837155838631592606550452777001897820070387740389506.
+Reading from /dev/fibonacci at offset 820, returned the sequence 1048045174780033280982112032380749378978942823968047223033506872248178847843130116268322754150645282034589830573131781690472704346283172529321174170898037453181519504646115.
+Reading from /dev/fibonacci at offset 821, returned the sequence 1695772714539417949653434023673260165702141888803417667127855950430528465750105937234985625226282526181535788629612657055309860184914765135871626947899935273251907245035621.
+Reading from /dev/fibonacci at offset 822, returned the sequence 2743817889319451230635546056054009544681084712771464890161362822678707313593236053503308379376927808216125619202744438745782564531197937665192801118797972726433426749681736.
+Reading from /dev/fibonacci at offset 823, returned the sequence 4439590603858869180288980079727269710383226601574882557289218773109235779343341990738294004603210334397661407832357095801092424716112702801064428066697907999685333994717357.
+Reading from /dev/fibonacci at offset 824, returned the sequence 7183408493178320410924526135781279255064311314346347447450581595787943092936578044241602383980138142613787027035101534546874989247310640466257229185495880726118760744399093.
+Reading from /dev/fibonacci at offset 825, returned the sequence 11622999097037189591213506215508548965447537915921230004739800368897178872279920034979896388583348477011448434867458630347967413963423343267321657252193788725804094739116450.
+Reading from /dev/fibonacci at offset 826, returned the sequence 18806407590215510002138032351289828220511849230267577452190381964685121965216498079221498772563486619625235461902560164894842403210733983733578886437689669451922855483515543.
+Reading from /dev/fibonacci at offset 827, returned the sequence 30429406687252699593351538566798377185959387146188807456930182333582300837496418114201395161146835096636683896770018795242809817174157327000900543689883458177726950222631993.
+Reading from /dev/fibonacci at offset 828, returned the sequence 49235814277468209595489570918088205406471236376456384909120564298267422802712916193422893933710321716261919358672578960137652220384891310734479430127573127629649805706147536.
+Reading from /dev/fibonacci at offset 829, returned the sequence 79665220964720909188841109484886582592430623522645192366050746631849723640209334307624289094857156812898603255442597755380462037559048637735379973817456585807376755928779529.
+Reading from /dev/fibonacci at offset 830, returned the sequence 128901035242189118784330680402974787998901859899101577275171310930117146442922250501047183028567478529160522614115176715518114257943939948469859403945029713437026561634927065.
+Reading from /dev/fibonacci at offset 831, returned the sequence 208566256206910027973171789887861370591332483421746769641222057561966870083131584808671472123424635342059125869557774470898576295502988586205239377762486299244403317563706594.
+Reading from /dev/fibonacci at offset 832, returned the sequence 337467291449099146757502470290836158590234343320848346916393368492084016526053835309718655151992113871219648483672951186416690553446928534675098781707516012681429879198633659.
+Reading from /dev/fibonacci at offset 833, returned the sequence 546033547656009174730674260178697529181566826742595116557615426054050886609185420118390127275416749213278774353230725657315266848949917120880338159470002311925833196762340253.
+Reading from /dev/fibonacci at offset 834, returned the sequence 883500839105108321488176730469533687771801170063443463474008794546134903135239255428108782427408863084498422836903676843731957402396845655555436941177518324607263075960973912.
+Reading from /dev/fibonacci at offset 835, returned the sequence 1429534386761117496218850990648231216953367996806038580031624220600185789744424675546498909702825612297777197190134402501047224251346762776435775100647520636533096272723314165.
+Reading from /dev/fibonacci at offset 836, returned the sequence 2313035225866225817707027721117764904725169166869482043505633015146320692879663930974607692130234475382275620027038079344779181653743608431991212041825038961140359348684288077.
+Reading from /dev/fibonacci at offset 837, returned the sequence 3742569612627343313925878711765996121678537163675520623537257235746506482624088606521106601833060087680052817217172481845826405905090371208426987142472559597673455621407602242.
+Reading from /dev/fibonacci at offset 838, returned the sequence 6055604838493569131632906432883761026403706330545002667042890250892827175503752537495714293963294563062328437244210561190605587558833979640418199184297598558813814970091890319.
+Reading from /dev/fibonacci at offset 839, returned the sequence 9798174451120912445558785144649757148082243494220523290580147486639333658127841144016820895796354650742381254461383043036431993463924350848845186326770158156487270591499492561.
+Reading from /dev/fibonacci at offset 840, returned the sequence 15853779289614481577191691577533518174485949824765525957623037737532160833631593681512535189759649213804709691705593604227037581022758330489263385511067756715301085561591382880.
+Reading from /dev/fibonacci at offset 841, returned the sequence 25651953740735394022750476722183275322568193318986049248203185224171494491759434825529356085556003864547090946166976647263469574486682681338108571837837914871788356153090875441.
+Reading from /dev/fibonacci at offset 842, returned the sequence 41505733030349875599942168299716793497054143143751575205826222961703655325391028507041891275315653078351800637872570251490507155509441011827371957348905671587089441714682258321.
+Reading from /dev/fibonacci at offset 843, returned the sequence 67157686771085269622692645021900068819622336462737624454029408185875149817150463332571247360871656942898891584039546898753976729996123693165480529186743586458877797867773133762.
+Reading from /dev/fibonacci at offset 844, returned the sequence 108663419801435145222634813321616862316676479606489199659855631147578805142541491839613138636187310021250692221912117150244483885505564704992852486535649258045967239582455392083.
+Reading from /dev/fibonacci at offset 845, returned the sequence 175821106572520414845327458343516931136298816069226824113885039333453954959691955172184385997058966964149583805951664048998460615501688398158333015722392844504845037450228525845.
+Reading from /dev/fibonacci at offset 846, returned the sequence 284484526373955560067962271665133793452975295675716023773740670481032760102233447011797524633246276985400276027863781199242944501007253103151185502258042102550812277032683917928.
+Reading from /dev/fibonacci at offset 847, returned the sequence 460305632946475974913289730008650724589274111744942847887625709814486715061925402183981910630305243949549859833815445248241405116508941501309518517980434947055657314482912443773.
+Reading from /dev/fibonacci at offset 848, returned the sequence 744790159320431534981252001673784518042249407420658871661366380295519475164158849195779435263551520934950135861679226447484349617516194604460704020238477049606469591515596361701.
+Reading from /dev/fibonacci at offset 849, returned the sequence 1205095792266907509894541731682435242631523519165601719548992090110006190226084251379761345893856764884499995695494671695725754734025136105770222538218911996662126905998508805474.
+Reading from /dev/fibonacci at offset 850, returned the sequence 1949885951587339044875793733356219760673772926586260591210358470405525665390243100575540781157408285819450131557173898143210104351541330710230926558457389046268596497514105167175.
+Reading from /dev/fibonacci at offset 851, returned the sequence 3154981743854246554770335465038655003305296445751862310759350560515531855616327351955302127051265050703950127252668569838935859085566466816001149096676301042930723403512613972649.
+Reading from /dev/fibonacci at offset 852, returned the sequence 5104867695441585599646129198394874763979069372338122901969709030921057521006570452530842908208673336523400258809842467982145963437107797526232075655133690089199319901026719139824.
+Reading from /dev/fibonacci at offset 853, returned the sequence 8259849439295832154416464663433529767284365818089985212729059591436589376622897804486145035259938387227350386062511037821081822522674264342233224751809991132130043304539333112473.
+Reading from /dev/fibonacci at offset 854, returned the sequence 13364717134737417754062593861828404531263435190428108114698768622357646897629468257016987943468611723750750644872353505803227785959782061868465300406943681221329363205566052252297.
+Reading from /dev/fibonacci at offset 855, returned the sequence 21624566574033249908479058525261934298547801008518093327427828213794236274252366061503132978728550110978101030934864543624309608482456326210698525158753672353459406510105385364770.
+Reading from /dev/fibonacci at offset 856, returned the sequence 34989283708770667662541652387090338829811236198946201442126596836151883171881834318520120922197161834728851675807218049427537394442238388079163825565697353574788769715671437617067.
+Reading from /dev/fibonacci at offset 857, returned the sequence 56613850282803917571020710912352273128359037207464294769554425049946119446134200380023253900925711945706952706742082593051847002924694714289862350724451025928248176225776822981837.
+Reading from /dev/fibonacci at offset 858, returned the sequence 91603133991574585233562363299442611958170273406410496211681021886098002618016034698543374823122873780435804382549300642479384397366933102369026176290148379503036945941448260598904.
+Reading from /dev/fibonacci at offset 859, returned the sequence 148216984274378502804583074211794885086529310613874790981235446936044122064150235078566628724048585726142757089291383235531231400291627816658888527014599405431285122167225083580741.
+Reading from /dev/fibonacci at offset 860, returned the sequence 239820118265953088038145437511237497044699584020285287192916468822142124682166269777110003547171459506578561471840683878010615797658560919027914703304747784934322068108673344179645.
+Reading from /dev/fibonacci at offset 861, returned the sequence 388037102540331590842728511723032382131228894634160078174151915758186246746316504855676632271220045232721318561132067113541847197950188735686803230319347190365607190275898427760386.
+Reading from /dev/fibonacci at offset 862, returned the sequence 627857220806284678880873949234269879175928478654445365367068384580328371428482774632786635818391504739299880032972750991552462995608749654714717933624094975299929258384571771940031.
+Reading from /dev/fibonacci at offset 863, returned the sequence 1015894323346616269723602460957302261307157373288605443541220300338514618174799279488463268089611549972021198594104818105094310193558938390401521163943442165665536448660470199700417.
+Reading from /dev/fibonacci at offset 864, returned the sequence 1643751544152900948604476410191572140483085851943050808908288684918842989603282054121249903908003054711321078627077569096646773189167688045116239097567537140965465707045041971640448.
+Reading from /dev/fibonacci at offset 865, returned the sequence 2659645867499517218328078871148874401790243225231656252449508985257357607778081333609713171997614604683342277221182387201741083382726626435517760261510979306631002155705512171340865.
+Reading from /dev/fibonacci at offset 866, returned the sequence 4303397411652418166932555281340446542273329077174707061357797670176200597381363387730963075905617659394663355848259956298387856571894314480633999359078516447596467862750554142981313.
+Reading from /dev/fibonacci at offset 867, returned the sequence 6963043279151935385260634152489320944063572302406363313807306655433558205159444721340676247903232264078005633069442343500128939954620940916151759620589495754227470018456066314322178.
+Reading from /dev/fibonacci at offset 868, returned the sequence 11266440690804353552193189433829767486336901379581070375165104325609758802540808109071639323808849923472668988917702299798516796526515255396785758979668012201823937881206620457303491.
+Reading from /dev/fibonacci at offset 869, returned the sequence 18229483969956288937453823586319088430400473681987433688972410981043317007700252830412315571712082187550674621987144643298645736481136196312937518600257507956051407899662686771625669.
+Reading from /dev/fibonacci at offset 870, returned the sequence 29495924660760642489647013020148855916737375061568504064137515306653075810241060939483954895520932111023343610904846943097162533007651451709723277579925520157875345780869307228929160.
+Reading from /dev/fibonacci at offset 871, returned the sequence 47725408630716931427100836606467944347137848743555937753109926287696392817941313769896270467233014298574018232891991586395808269488787648022660796180183028113926753680531994000554829.
+Reading from /dev/fibonacci at offset 872, returned the sequence 77221333291477573916747849626616800263875223805124441817247441594349468628182374709380225362753946409597361843796838529492970802496439099732384073760108548271802099461401301229483989.
+Reading from /dev/fibonacci at offset 873, returned the sequence 124946741922194505343848686233084744611013072548680379570357367882045861446123688479276495829986960708171380076688830115888779071985226747755044869940291576385728853141933295230038818.
+Reading from /dev/fibonacci at offset 874, returned the sequence 202168075213672079260596535859701544874888296353804821387604809476395330074306063188656721192740907117768741920485668645381749874481665847487428943700400124657530952603334596459522807.
+Reading from /dev/fibonacci at offset 875, returned the sequence 327114817135866584604445222092786289485901368902485200957962177358441191520429751667933217022727867825940121997174498761270528946466892595242473813640691701043259805745267891689561625.
+Reading from /dev/fibonacci at offset 876, returned the sequence 529282892349538663865041757952487834360789665256290022345566986834836521594735814856589938215468774943708863917660167406652278820948558442729902757341091825700790758348602488149084432.
+Reading from /dev/fibonacci at offset 877, returned the sequence 856397709485405248469486980045274123846691034158775223303529164193277713115165566524523155238196642769648985914834666167922807767415451037972376570981783526744050564093870379838646057.
+Reading from /dev/fibonacci at offset 878, returned the sequence 1385680601834943912334528737997761958207480699415065245649096151028114234709901381381113093453665417713357849832494833574575086588364009480702279328322875352444841322442472867987730489.
+Reading from /dev/fibonacci at offset 879, returned the sequence 2242078311320349160804015718043036082054171733573840468952625315221391947825066947905636248691862060483006835747329499742497894355779460518674655899304658879188891886536343247826376546.
+Reading from /dev/fibonacci at offset 880, returned the sequence 3627758913155293073138544456040798040261652432988905714601721466249506182534968329286749342145527478196364685579824333317072980944143469999376935227627534231633733208978816115814107035.
+Reading from /dev/fibonacci at offset 881, returned the sequence 5869837224475642233942560174083834122315824166562746183554346781470898130360035277192385590837389538679371521327153833059570875299922930518051591126932193110822625095515159363640483581.
+Reading from /dev/fibonacci at offset 882, returned the sequence 9497596137630935307081104630124632162577476599551651898156068247720404312895003606479134932982917016875736206906978166376643856244066400517428526354559727342456358304493975479454590616.
+Reading from /dev/fibonacci at offset 883, returned the sequence 15367433362106577541023664804208466284893300766114398081710415029191302443255038883671520523820306555555107728234131999436214731543989331035480117481491920453278983400009134843095074197.
+Reading from /dev/fibonacci at offset 884, returned the sequence 24865029499737512848104769434333098447470777365666049979866483276911706756150042490150655456803223572430843935141110165812858587788055731552908643836051647795735341704503110322549664813.
+Reading from /dev/fibonacci at offset 885, returned the sequence 40232462861844090389128434238541564732364078131780448061576898306103009199405081373822175980623530127985951663375242165249073319332045062588388761317543568249014325104512245165644739010.
+Reading from /dev/fibonacci at offset 886, returned the sequence 65097492361581603237233203672874663179834855497446498041443381583014715955555123863972831437426753700416795598516352331061931907120100794141297405153595216044749666809015355488194403823.
+Reading from /dev/fibonacci at offset 887, returned the sequence 105329955223425693626361637911416227912198933629226946103020279889117725154960205237795007418050283828402747261891594496311005226452145856729686166471138784293763991913527600653839142833.
+Reading from /dev/fibonacci at offset 888, returned the sequence 170427447585007296863594841584290891092033789126673444144463661472132441110515329101767838855477037528819542860407946827372937133572246650870983571624734000338513658722542956142033546656.
+Reading from /dev/fibonacci at offset 889, returned the sequence 275757402808432990489956479495707119004232722755900390247483941361250166265475534339562846273527321357222290122299541323683942360024392507600669738095872784632277650636070556795872689489.
+Reading from /dev/fibonacci at offset 890, returned the sequence 446184850393440287353551321079998010096266511882573834391947602833382607375990863441330685129004358886041832982707488151056879493596639158471653309720606784970791309358613512937906236145.
+Reading from /dev/fibonacci at offset 891, returned the sequence 721942253201873277843507800575705129100499234638474224639431544194632773641466397780893531402531680243264123105007029474740821853621031666072323047816479569603068959994684069733778925634.
+Reading from /dev/fibonacci at offset 892, returned the sequence 1168127103595313565197059121655703139196765746521048059031379147028015381017457261222224216531536039129305956087714517625797701347217670824543976357537086354573860269353297582671685161779.
+Reading from /dev/fibonacci at offset 893, returned the sequence 1890069356797186843040566922231408268297264981159522283670810691222648154658923659003117747934067719372570079192721547100538523200838702490616299405353565924176929229347981652405464087413.
+Reading from /dev/fibonacci at offset 894, returned the sequence 3058196460392500408237626043887111407494030727680570342702189838250663535676380920225341964465603758501876035280436064726336224548056373315160275762890652278750789498701279235077149249192.
+Reading from /dev/fibonacci at offset 895, returned the sequence 4948265817189687251278192966118519675791295708840092626373000529473311690335304579228459712399671477874446114473157611826874747748895075805776575168244218202927718728049260887482613336605.
+Reading from /dev/fibonacci at offset 896, returned the sequence 8006462277582187659515819010005631083285326436520662969075190367723975226011685499453801676865275236376322149753593676553210972296951449120936850931134870481678508226750540122559762585797.
+Reading from /dev/fibonacci at offset 897, returned the sequence 12954728094771874910794011976124150759076622145360755595448190897197286916346990078682261389264946714250768264226751288380085720045846524926713426099379088684606226954799801010042375922402.
+Reading from /dev/fibonacci at offset 898, returned the sequence 20961190372354062570309830986129781842361948581881418564523381264921262142358675578136063066130221950627090413980344964933296692342797974047650277030513959166284735181550341132602138508199.
+Reading from /dev/fibonacci at offset 899, returned the sequence 33915918467125937481103842962253932601438570727242174159971572162118549058705665656818324455395168664877858678207096253313382412388644498974363703129893047850890962136350142142644514430601.
+Reading from /dev/fibonacci at offset 900, returned the sequence 54877108839480000051413673948383714443800519309123592724494953427039811201064341234954387521525390615504949092187441218246679104731442473022013980160407007017175697317900483275246652938800.
+Reading from /dev/fibonacci at offset 901, returned the sequence 88793027306605937532517516910637647045239090036365766884466525589158360259770006891772711976920559280382807770394537471560061517120086971996377683290300054868066659454250625417891167369401.
+Reading from /dev/fibonacci at offset 902, returned the sequence 143670136146085937583931190859021361489039609345489359608961479016198171460834348126727099498445949895887756862581978689806740621851529445018391663450707061885242356772151108693137820308201.
+Reading from /dev/fibonacci at offset 903, returned the sequence 232463163452691875116448707769659008534278699381855126493428004605356531720604355018499811475366509176270564632976516161366802138971616417014769346741007116753309016226401734111028987677602.
+Reading from /dev/fibonacci at offset 904, returned the sequence 376133299598777812700379898628680370023318308727344486102389483621554703181438703145226910973812459072158321495558494851173542760823145862033161010191714178638551372998552842804166807985803.
+Reading from /dev/fibonacci at offset 905, returned the sequence 608596463051469687816828606398339378557597008109199612595817488226911234902043058163726722449178968248428886128535011012540344899794762279047930356932721295391860389224954576915195795663405.
+Reading from /dev/fibonacci at offset 906, returned the sequence 984729762650247500517208505027019748580915316836544098698206971848465938083481761308953633422991427320587207624093505863713887660617908141081091367124435474030411762223507419719362603649208.
+Reading from /dev/fibonacci at offset 907, returned the sequence 1593326225701717188334037111425359127138512324945743711294024460075377172985524819472680355872170395569016093752628516876254232560412670420129021724057156769422272151448461996634558399312613.
+Reading from /dev/fibonacci at offset 908, returned the sequence 2578055988351964688851245616452378875719427641782287809992231431923843111069006580781633989295161822889603301376722022739968120221030578561210113091181592243452683913671969416353921002961821.
+Reading from /dev/fibonacci at offset 909, returned the sequence 4171382214053681877185282727877738002857939966728031521286255891999220284054531400254314345167332218458619395129350539616222352781443248981339134815238749012874956065120431412988479402274434.
+Reading from /dev/fibonacci at offset 910, returned the sequence 6749438202405646566036528344330116878577367608510319331278487323923063395123537981035948334462494041348222696506072562356190473002473827542549247906420341256327639978792400829342400405236255.
+Reading from /dev/fibonacci at offset 911, returned the sequence 10920820416459328443221811072207854881435307575238350852564743215922283679178069381290262679629826259806842091635423101972412825783917076523888382721659090269202596043912832242330879807510689.
+Reading from /dev/fibonacci at offset 912, returned the sequence 17670258618864975009258339416537971760012675183748670183843230539845347074301607362326211014092320301155064788141495664328603298786390904066437630628079431525530236022705233071673280212746944.
+Reading from /dev/fibonacci at offset 913, returned the sequence 28591079035324303452480150488745826641447982758987021036407973755767630753479676743616473693722146560961906879776918766301016124570307980590326013349738521794732832066618065314004160020257633.
+Reading from /dev/fibonacci at offset 914, returned the sequence 46261337654189278461738489905283798401460657942735691220251204295612977827781284105942684707814466862116971667918414430629619423356698884656763643977817953320263068089323298385677440233004577.
+Reading from /dev/fibonacci at offset 915, returned the sequence 74852416689513581914218640394029625042908640701722712256659178051380608581260960849559158401536613423078878547695333196930635547927006865247089657327556475114995900155941363699681600253262210.
+Reading from /dev/fibonacci at offset 916, returned the sequence 121113754343702860375957130299313423444369298644458403476910382346993586409042244955501843109351080285195850215613747627560254971283705749903853301305374428435258968245264662085359040486266787.
+Reading from /dev/fibonacci at offset 917, returned the sequence 195966171033216442290175770693343048487277939346181115733569560398374194990303205805061001510887693708274728763309080824490890519210712615150942958632930903550254868401206025785040640739528997.
+Reading from /dev/fibonacci at offset 918, returned the sequence 317079925376919302666132900992656471931647237990639519210479942745367781399345450760562844620238773993470578978922828452051145490494418365054796259938305331985513836646470687870399681225795784.
+Reading from /dev/fibonacci at offset 919, returned the sequence 513046096410135744956308671685999520418925177336820634944049503143741976389648656565623846131126467701745307742231909276542036009705130980205739218571236235535768705047676713655440321965324781.
+Reading from /dev/fibonacci at offset 920, returned the sequence 830126021787055047622441572678655992350572415327460154154529445889109757788994107326186690751365241695215886721154737728593181500199549345260535478509541567521282541694147401525840003191120565.
+Reading from /dev/fibonacci at offset 921, returned the sequence 1343172118197190792578750244364655512769497592664280789098578949032851734178642763891810536882491709396961194463386647005135217509904680325466274697080777803057051246741824115181280325156445346.
+Reading from /dev/fibonacci at offset 922, returned the sequence 2173298139984245840201191817043311505120070007991740943253108394921961491967636871217997227633856951092177081184541384733728399010104229670726810175590319370578333788435971516707120328347565911.
+Reading from /dev/fibonacci at offset 923, returned the sequence 3516470258181436632779942061407967017889567600656021732351687343954813226146279635109807764516348660489138275647928031738863616520008909996193084872671097173635385035177795631888400653504011257.
+Reading from /dev/fibonacci at offset 924, returned the sequence 5689768398165682472981133878451278523009637608647762675604795738876774718113916506327804992150205611581315356832469416472592015530113139666919895048261416544213718823613767148595520981851577168.
+Reading from /dev/fibonacci at offset 925, returned the sequence 9206238656347119105761075939859245540899205209303784407956483082831587944260196141437612756666554272070453632480397448211455632050122049663112979920932513717849103858791562780483921635355588425.
+Reading from /dev/fibonacci at offset 926, returned the sequence 14896007054512801578742209818310524063908842817951547083561278821708362662374112647765417748816759883651768989312866864684047647580235189330032874969193930262062822682405329929079442617207165593.
+Reading from /dev/fibonacci at offset 927, returned the sequence 24102245710859920684503285758169769604808048027255331491517761904539950606634308789203030505483314155722222621793264312895503279630357238993145854890126443979911926541196892709563364252562754018.
+Reading from /dev/fibonacci at offset 928, returned the sequence 38998252765372722263245495576480293668716890845206878575079040726248313269008421436968448254300074039373991611106131177579550927210592428323178729859320374241974749223602222638642806869769919611.
+Reading from /dev/fibonacci at offset 929, returned the sequence 63100498476232642947748781334650063273524938872462210066596802630788263875642730226171478759783388195096214232899395490475054206840949667316324584749446818221886675764799115348206171122332673629.
+Reading from /dev/fibonacci at offset 930, returned the sequence 102098751241605365210994276911130356942241829717669088641675843357036577144651151663139927014083462234470205844005526668054605134051542095639503314608767192463861424988401337986848977992102593240.
+Reading from /dev/fibonacci at offset 931, returned the sequence 165199249717838008158743058245780420215766768590131298708272645987824841020293881889311405773866850429566420076904922158529659340892491762955827899358214010685748100753200453335055149114435266869.
+Reading from /dev/fibonacci at offset 932, returned the sequence 267298000959443373369737335156910777158008598307800387349948489344861418164945033552451332787950312664036625920910448826584264474944033858595331213966981203149609525741601791321904127106537860109.
+Reading from /dev/fibonacci at offset 933, returned the sequence 432497250677281381528480393402691197373775366897931686058221135332686259185238915441762738561817163093603045997815370985113923815836525621551159113325195213835357626494802244656959276220973126978.
+Reading from /dev/fibonacci at offset 934, returned the sequence 699795251636724754898217728559601974531783965205732073408169624677547677350183948994214071349767475757639671918725819811698188290780559480146490327292176416984967152236404035978863403327510987087.
+Reading from /dev/fibonacci at offset 935, returned the sequence 1132292502314006136426698121962293171905559332103663759466390760010233936535422864435976809911584638851242717916541190796812112106617085101697649440617371630820324778731206280635822679548484114065.
+Reading from /dev/fibonacci at offset 936, returned the sequence 1832087753950730891324915850521895146437343297309395832874560384687781613885606813430190881261352114608882389835267010608510300397397644581844139767909548047805291930967610316614686082875995101152.
+Reading from /dev/fibonacci at offset 937, returned the sequence 2964380256264737027751613972484188318342902629413059592340951144698015550421029677866167691172936753460125107751808201405322412504014729683541789208526919678625616709698816597250508762424479215217.
+Reading from /dev/fibonacci at offset 938, returned the sequence 4796468010215467919076529823006083464780245926722455425215511529385797164306636491296358572434288868069007497587075212013832712901412374265385928976436467726430908640666426913865194845300474316369.
+Reading from /dev/fibonacci at offset 939, returned the sequence 7760848266480204946828143795490271783123148556135515017556462674083812714727666169162526263607225621529132605338883413419155125405427103948927718184963387405056525350365243511115703607724953531586.
+Reading from /dev/fibonacci at offset 940, returned the sequence 12557316276695672865904673618496355247903394482857970442771974203469609879034302660458884836041514489598140102925958625432987838306839478214313647161399855131487433991031670424980898453025427847955.
+Reading from /dev/fibonacci at offset 941, returned the sequence 20318164543175877812732817413986627031026543038993485460328436877553422593761968829621411099648740111127272708264842038852142963712266582163241365346363242536543959341396913936096602060750381379541.
+Reading from /dev/fibonacci at offset 942, returned the sequence 32875480819871550678637491032482982278929937521851455903100411081023032472796271490080295935690254600725412811190800664285130802019106060377555012507763097668031393332428584361077500513775809227496.
+Reading from /dev/fibonacci at offset 943, returned the sequence 53193645363047428491370308446469609309956480560844941363428847958576455066558240319701707035338994711852685519455642703137273765731372642540796377854126340204575352673825498297174102574526190607037.
+Reading from /dev/fibonacci at offset 944, returned the sequence 86069126182918979170007799478952591588886418082696397266529259039599487539354511809782002971029249312578098330646443367422404567750478702918351390361889437872606746006254082658251603088301999834533.
+Reading from /dev/fibonacci at offset 945, returned the sequence 139262771545966407661378107925422200898842898643541338629958106998175942605912752129483710006368244024430783850102086070559678333481851345459147768216015778077182098680079580955425705662828190441570.
+Reading from /dev/fibonacci at offset 946, returned the sequence 225331897728885386831385907404374792487729316726237735896487366037775430145267263939265712977397493337008882180748529437982082901232330048377499158577905215949788844686333663613677308751130190276103.
+Reading from /dev/fibonacci at offset 947, returned the sequence 364594669274851794492764015329796993386572215369779074526445473035951372751180016068749422983765737361439666030850615508541761234714181393836646926793920994026970943366413244569103014413958380717673.
+Reading from /dev/fibonacci at offset 948, returned the sequence 589926567003737181324149922734171785874301532096016810422932839073726802896447280008015135961163230698448548211599144946523844135946511442214146085371826209976759788052746908182780323165088570993776.
+Reading from /dev/fibonacci at offset 949, returned the sequence 954521236278588975816913938063968779260873747465795884949378312109678175647627296076764558944928968059888214242449760455065605370660692836050793012165747204003730731419160152751883337579046951711449.
+Reading from /dev/fibonacci at offset 950, returned the sequence 1544447803282326157141063860798140565135175279561812695372311151183404978544074576084779694906092198758336762454048905401589449506607204278264939097537573413980490519471907060934663660744135522705225.
+Reading from /dev/fibonacci at offset 951, returned the sequence 2498969039560915132957977798862109344396049027027608580321689463293083154191701872161544253851021166818224976696498665856655054877267897114315732109703320617984221250891067213686546998323182474416674.
+Reading from /dev/fibonacci at offset 952, returned the sequence 4043416842843241290099041659660249909531224306589421275694000614476488132735776448246323948757113365576561739150547571258244504383875101392580671207240894031964711770362974274621210659067317997121899.
+Reading from /dev/fibonacci at offset 953, returned the sequence 6542385882404156423057019458522359253927273333617029856015690077769571286927478320407868202608134532394786715847046237114899559261142998506896403316944214649948933021254041488307757657390500471538573.
+Reading from /dev/fibonacci at offset 954, returned the sequence 10585802725247397713156061118182609163458497640206451131709690692246059419663254768654192151365247897971348454997593808373144063645018099899477074524185108681913644791617015762928968316457818468660472.
+Reading from /dev/fibonacci at offset 955, returned the sequence 17128188607651554136213080576704968417385770973823480987725380770015630706590733089062060353973382430366135170844640045488043622906161098406373477841129323331862577812871057251236725973848318940199045.
+Reading from /dev/fibonacci at offset 956, returned the sequence 27713991332898951849369141694887577580844268614029932119435071462261690126253987857716252505338630328337483625842233853861187686551179198305850552365314432013776222604488073014165694290306137408859517.
+Reading from /dev/fibonacci at offset 957, returned the sequence 44842179940550505985582222271592545998230039587853413107160452232277320832844720946778312859312012758703618796686873899349231309457340296712224030206443755345638800417359130265402420264154456349058562.
+Reading from /dev/fibonacci at offset 958, returned the sequence 72556171273449457834951363966480123579074308201883345226595523694539010959098708804494565364650643087041102422529107753210418996008519495018074582571758187359415023021847203279568114554460593757918079.
+Reading from /dev/fibonacci at offset 959, returned the sequence 117398351213999963820533586238072669577304347789736758333755975926816331791943429751272878223962655845744721219215981652559650305465859791730298612778201942705053823439206333544970534818615050106976641.
+Reading from /dev/fibonacci at offset 960, returned the sequence 189954522487449421655484950204552793156378655991620103560351499621355342751042138555767443588613298932785823641745089405770069301474379286748373195349960130064468846461053536824538649373075643864894720.
+Reading from /dev/fibonacci at offset 961, returned the sequence 307352873701449385476018536442625462733683003781356861894107475548171674542985568307040321812575954778530544860961071058329719606940239078478671808128162072769522669900259870369509184191690693971871361.
+Reading from /dev/fibonacci at offset 962, returned the sequence 497307396188898807131503486647178255890061659772976965454458975169527017294027706862807765401189253711316368502706160464099788908414618365227045003478122202833991516361313407194047833564766337836766081.
+Reading from /dev/fibonacci at offset 963, returned the sequence 804660269890348192607522023089803718623744663554333827348566450717698691837013275169848087213765208489846913363667231522429508515354857443705716811606284275603514186261573277563557017756457031808637442.
+Reading from /dev/fibonacci at offset 964, returned the sequence 1301967666079246999739025509736981974513806323327310792803025425887225709131040982032655852614954462201163281866373391986529297423769475808932761815084406478437505702622886684757604851321223369645403523.
+Reading from /dev/fibonacci at offset 965, returned the sequence 2106627935969595192346547532826785693137550986881644620151591876604924400968054257202503939828719670691010195230040623508958805939124333252638478626690690754041019888884459962321161869077680401454040965.
+Reading from /dev/fibonacci at offset 966, returned the sequence 3408595602048842192085573042563767667651357310208955412954617302492150110099095239235159792443674132892173477096414015495488103362893809061571240441775097232478525591507346647078766720398903771099444488.
+Reading from /dev/fibonacci at offset 967, returned the sequence 5515223538018437384432120575390553360788908297090600033106209179097074511067149496437663732272393803583183672326454639004446909302018142314209719068465787986519545480391806609399928589476584172553485453.
+Reading from /dev/fibonacci at offset 968, returned the sequence 8923819140067279576517693617954321028440265607299555446060826481589224621166244735672823524716067936475357149422868654499935012664911951375780959510240885218998071071899153256478695309875487943652929941.
+Reading from /dev/fibonacci at offset 969, returned the sequence 14439042678085716960949814193344874389229173904390155479167035660686299132233394232110487256988461740058540821749323293504381921966930093689990678578706673205517616552290959865878623899352072116206415394.
+Reading from /dev/fibonacci at offset 970, returned the sequence 23362861818152996537467507811299195417669439511689710925227862142275523753399638967783310781704529676533897971172191948004316934631842045065771638088947558424515687624190113122357319209227560059859345335.
+Reading from /dev/fibonacci at offset 971, returned the sequence 37801904496238713498417322004644069806898613416079866404394897802961822885633033199893798038692991416592438792921515241508698856598772138755762316667654231630033304176481072988235943108579632176065760729.
+Reading from /dev/fibonacci at offset 972, returned the sequence 61164766314391710035884829815943265224568052927769577329622759945237346639032672167677108820397521093126336764093707189513015791230614183821533954756601790054548991800671186110593262317807192235925106064.
+Reading from /dev/fibonacci at offset 973, returned the sequence 98966670810630423534302151820587335031466666343849443734017657748199169524665705367570906859090512509718775557015222431021714647829386322577296271424256021684582295977152259098829205426386824411990866793.
+Reading from /dev/fibonacci at offset 974, returned the sequence 160131437125022133570186981636530600256034719271619021063640417693436516163698377535248015679488033602845112321108929620534730439060000506398830226180857811739131287777823445209422467744194016647915972857.
+Reading from /dev/fibonacci at offset 975, returned the sequence 259098107935652557104489133457117935287501385615468464797658075441635685688364082902818922538578546112563887878124152051556445086889386828976126497605113833423713583754975704308251673170580841059906839650.
+Reading from /dev/fibonacci at offset 976, returned the sequence 419229545060674690674676115093648535543536104887087485861298493135072201852062460438066938218066579715409000199233081672091175525949387335374956723785971645162844871532799149517674140914774857707822812507.
+Reading from /dev/fibonacci at offset 977, returned the sequence 678327652996327247779165248550766470831037490502555950658956568576707887540426543340885860756645125827972888077357233723647620612838774164351083221391085478586558455287774853825925814085355698767729652157.
+Reading from /dev/fibonacci at offset 978, returned the sequence 1097557198057001938453841363644415006374573595389643436520255061711780089392489003778952798974711705543381888276590315395738796138788161499726039945177057123749403326820574003343599955000130556475552464664.
+Reading from /dev/fibonacci at offset 979, returned the sequence 1775884851053329186233006612195181477205611085892199387179211630288487976932915547119838659731356831371354776353947549119386416751626935664077123166568142602335961782108348857169525769085486255243282116821.
+Reading from /dev/fibonacci at offset 980, returned the sequence 2873442049110331124686847975839596483580184681281842823699466692000268066325404550898791458706068536914736664630537864515125212890415097163803163111745199726085365108928922860513125724085616811718834581485.
+Reading from /dev/fibonacci at offset 981, returned the sequence 4649326900163660310919854588034777960785795767174042210878678322288756043258320098018630118437425368286091440984485413634511629642042032827880286278313342328421326891037271717682651493171103066962116698306.
+Reading from /dev/fibonacci at offset 982, returned the sequence 7522768949273991435606702563874374444365980448455885034578145014289024109583724648917421577143493905200828105615023278149636842532457129991683449390058542054506691999966194578195777217256719878680951279791.
+Reading from /dev/fibonacci at offset 983, returned the sequence 12172095849437651746526557151909152405151776215629927245456823336577780152842044746936051695580919273486919546599508691784148472174499162819563735668371884382928018891003466295878428710427822945643067978097.
+Reading from /dev/fibonacci at offset 984, returned the sequence 19694864798711643182133259715783526849517756664085812280034968350866804262425769395853473272724413178687747652214531969933785314706956292811247185058430426437434710890969660874074205927684542824324019257888.
+Reading from /dev/fibonacci at offset 985, returned the sequence 31866960648149294928659816867692679254669532879715739525491791687444584415267814142789524968305332452174667198814040661717933786881455455630810920726802310820362729781973127169952634638112365769967087235985.
+Reading from /dev/fibonacci at offset 986, returned the sequence 51561825446860938110793076583476206104187289543801551805526760038311388677693583538642998241029745630862414851028572631651719101588411748442058105785232737257797440672942788044026840565796908594291106493873.
+Reading from /dev/fibonacci at offset 987, returned the sequence 83428786095010233039452893451168885358856822423517291331018551725755973092961397681432523209335078083037082049842613293369652888469867204072869026512035048078160170454915915213979475203909274364258193729858.
+Reading from /dev/fibonacci at offset 988, returned the sequence 134990611541871171150245970034645091463044111967318843136545311764067361770654981220075521450364823713899496900871185925021371990058278952514927132297267785335957611127858703258006315769706182958549300223731.
+Reading from /dev/fibonacci at offset 989, returned the sequence 218419397636881404189698863485813976821900934390836134467563863489823334863616378901508044659699901796936578950713799218391024878528146156587796158809302833414117781582774618471985790973615457322807493953589.
+Reading from /dev/fibonacci at offset 990, returned the sequence 353410009178752575339944833520459068284945046358154977604109175253890696634271360121583566110064725510836075851584985143412396868586425109102723291106570618750075392710633321729992106743321640281356794177320.
+Reading from /dev/fibonacci at offset 991, returned the sequence 571829406815633979529643697006273045106845980748991112071673038743714031497887739023091610769764627307772654802298784361803421747114571265690519449915873452164193174293407940201977897716937097604164288130909.
+Reading from /dev/fibonacci at offset 992, returned the sequence 925239415994386554869588530526732113391791027107146089675782213997604728132159099144675176879829352818608730653883769505215818615700996374793242741022444070914268567004041261931970004460258737885521082308229.
+Reading from /dev/fibonacci at offset 993, returned the sequence 1497068822810020534399232227533005158498637007856137201747455252741318759630046838167766787649593980126381385456182553867019240362815567640483762190938317523078461741297449202133947902177195835489685370439138.
+Reading from /dev/fibonacci at offset 994, returned the sequence 2422308238804407089268820758059737271890428034963283291423237466738923487762205937312441964529423332944990116110066323372235058978516564015277004931960761593992730308301490464065917906637454573375206452747367.
+Reading from /dev/fibonacci at offset 995, returned the sequence 3919377061614427623668052985592742430389065042819420493170692719480242247392252775480208752179017313071371501566248877239254299341332131655760767122899079117071192049598939666199865808814650408864891823186505.
+Reading from /dev/fibonacci at offset 996, returned the sequence 6341685300418834712936873743652479702279493077782703784593930186219165735154458712792650716708440646016361617676315200611489358319848695671037772054859840711063922357900430130265783715452104982240098275933872.
+Reading from /dev/fibonacci at offset 997, returned the sequence 10261062362033262336604926729245222132668558120602124277764622905699407982546711488272859468887457959087733119242564077850743657661180827326798539177758919828135114407499369796465649524266755391104990099120377.
+Reading from /dev/fibonacci at offset 998, returned the sequence 16602747662452097049541800472897701834948051198384828062358553091918573717701170201065510185595898605104094736918879278462233015981029522997836311232618760539199036765399799926731433239718860373345088375054249.
+Reading from /dev/fibonacci at offset 999, returned the sequence 26863810024485359386146727202142923967616609318986952340123175997617981700247881689338369654483356564191827856161443356312976673642210350324634850410377680367334151172899169723197082763985615764450078474174626.
+Reading from /dev/fibonacci at offset 1000, returned the sequence 43466557686937456435688527675040625802564660517371780402481729089536555417949051890403879840079255169295922593080322634775209689623239873322471161642996440906533187938298969649928516003704476137795166849228875.
+Reading from /dev/fibonacci at offset 1000, returned the sequence 43466557686937456435688527675040625802564660517371780402481729089536555417949051890403879840079255169295922593080322634775209689623239873322471161642996440906533187938298969649928516003704476137795166849228875.
+Reading from /dev/fibonacci at offset 999, returned the sequence 26863810024485359386146727202142923967616609318986952340123175997617981700247881689338369654483356564191827856161443356312976673642210350324634850410377680367334151172899169723197082763985615764450078474174626.
+Reading from /dev/fibonacci at offset 998, returned the sequence 16602747662452097049541800472897701834948051198384828062358553091918573717701170201065510185595898605104094736918879278462233015981029522997836311232618760539199036765399799926731433239718860373345088375054249.
+Reading from /dev/fibonacci at offset 997, returned the sequence 10261062362033262336604926729245222132668558120602124277764622905699407982546711488272859468887457959087733119242564077850743657661180827326798539177758919828135114407499369796465649524266755391104990099120377.
+Reading from /dev/fibonacci at offset 996, returned the sequence 6341685300418834712936873743652479702279493077782703784593930186219165735154458712792650716708440646016361617676315200611489358319848695671037772054859840711063922357900430130265783715452104982240098275933872.
+Reading from /dev/fibonacci at offset 995, returned the sequence 3919377061614427623668052985592742430389065042819420493170692719480242247392252775480208752179017313071371501566248877239254299341332131655760767122899079117071192049598939666199865808814650408864891823186505.
+Reading from /dev/fibonacci at offset 994, returned the sequence 2422308238804407089268820758059737271890428034963283291423237466738923487762205937312441964529423332944990116110066323372235058978516564015277004931960761593992730308301490464065917906637454573375206452747367.
+Reading from /dev/fibonacci at offset 993, returned the sequence 1497068822810020534399232227533005158498637007856137201747455252741318759630046838167766787649593980126381385456182553867019240362815567640483762190938317523078461741297449202133947902177195835489685370439138.
+Reading from /dev/fibonacci at offset 992, returned the sequence 925239415994386554869588530526732113391791027107146089675782213997604728132159099144675176879829352818608730653883769505215818615700996374793242741022444070914268567004041261931970004460258737885521082308229.
+Reading from /dev/fibonacci at offset 991, returned the sequence 571829406815633979529643697006273045106845980748991112071673038743714031497887739023091610769764627307772654802298784361803421747114571265690519449915873452164193174293407940201977897716937097604164288130909.
+Reading from /dev/fibonacci at offset 990, returned the sequence 353410009178752575339944833520459068284945046358154977604109175253890696634271360121583566110064725510836075851584985143412396868586425109102723291106570618750075392710633321729992106743321640281356794177320.
+Reading from /dev/fibonacci at offset 989, returned the sequence 218419397636881404189698863485813976821900934390836134467563863489823334863616378901508044659699901796936578950713799218391024878528146156587796158809302833414117781582774618471985790973615457322807493953589.
+Reading from /dev/fibonacci at offset 988, returned the sequence 134990611541871171150245970034645091463044111967318843136545311764067361770654981220075521450364823713899496900871185925021371990058278952514927132297267785335957611127858703258006315769706182958549300223731.
+Reading from /dev/fibonacci at offset 987, returned the sequence 83428786095010233039452893451168885358856822423517291331018551725755973092961397681432523209335078083037082049842613293369652888469867204072869026512035048078160170454915915213979475203909274364258193729858.
+Reading from /dev/fibonacci at offset 986, returned the sequence 51561825446860938110793076583476206104187289543801551805526760038311388677693583538642998241029745630862414851028572631651719101588411748442058105785232737257797440672942788044026840565796908594291106493873.
+Reading from /dev/fibonacci at offset 985, returned the sequence 31866960648149294928659816867692679254669532879715739525491791687444584415267814142789524968305332452174667198814040661717933786881455455630810920726802310820362729781973127169952634638112365769967087235985.
+Reading from /dev/fibonacci at offset 984, returned the sequence 19694864798711643182133259715783526849517756664085812280034968350866804262425769395853473272724413178687747652214531969933785314706956292811247185058430426437434710890969660874074205927684542824324019257888.
+Reading from /dev/fibonacci at offset 983, returned the sequence 12172095849437651746526557151909152405151776215629927245456823336577780152842044746936051695580919273486919546599508691784148472174499162819563735668371884382928018891003466295878428710427822945643067978097.
+Reading from /dev/fibonacci at offset 982, returned the sequence 7522768949273991435606702563874374444365980448455885034578145014289024109583724648917421577143493905200828105615023278149636842532457129991683449390058542054506691999966194578195777217256719878680951279791.
+Reading from /dev/fibonacci at offset 981, returned the sequence 4649326900163660310919854588034777960785795767174042210878678322288756043258320098018630118437425368286091440984485413634511629642042032827880286278313342328421326891037271717682651493171103066962116698306.
+Reading from /dev/fibonacci at offset 980, returned the sequence 2873442049110331124686847975839596483580184681281842823699466692000268066325404550898791458706068536914736664630537864515125212890415097163803163111745199726085365108928922860513125724085616811718834581485.
+Reading from /dev/fibonacci at offset 979, returned the sequence 1775884851053329186233006612195181477205611085892199387179211630288487976932915547119838659731356831371354776353947549119386416751626935664077123166568142602335961782108348857169525769085486255243282116821.
+Reading from /dev/fibonacci at offset 978, returned the sequence 1097557198057001938453841363644415006374573595389643436520255061711780089392489003778952798974711705543381888276590315395738796138788161499726039945177057123749403326820574003343599955000130556475552464664.
+Reading from /dev/fibonacci at offset 977, returned the sequence 678327652996327247779165248550766470831037490502555950658956568576707887540426543340885860756645125827972888077357233723647620612838774164351083221391085478586558455287774853825925814085355698767729652157.
+Reading from /dev/fibonacci at offset 976, returned the sequence 419229545060674690674676115093648535543536104887087485861298493135072201852062460438066938218066579715409000199233081672091175525949387335374956723785971645162844871532799149517674140914774857707822812507.
+Reading from /dev/fibonacci at offset 975, returned the sequence 259098107935652557104489133457117935287501385615468464797658075441635685688364082902818922538578546112563887878124152051556445086889386828976126497605113833423713583754975704308251673170580841059906839650.
+Reading from /dev/fibonacci at offset 974, returned the sequence 160131437125022133570186981636530600256034719271619021063640417693436516163698377535248015679488033602845112321108929620534730439060000506398830226180857811739131287777823445209422467744194016647915972857.
+Reading from /dev/fibonacci at offset 973, returned the sequence 98966670810630423534302151820587335031466666343849443734017657748199169524665705367570906859090512509718775557015222431021714647829386322577296271424256021684582295977152259098829205426386824411990866793.
+Reading from /dev/fibonacci at offset 972, returned the sequence 61164766314391710035884829815943265224568052927769577329622759945237346639032672167677108820397521093126336764093707189513015791230614183821533954756601790054548991800671186110593262317807192235925106064.
+Reading from /dev/fibonacci at offset 971, returned the sequence 37801904496238713498417322004644069806898613416079866404394897802961822885633033199893798038692991416592438792921515241508698856598772138755762316667654231630033304176481072988235943108579632176065760729.
+Reading from /dev/fibonacci at offset 970, returned the sequence 23362861818152996537467507811299195417669439511689710925227862142275523753399638967783310781704529676533897971172191948004316934631842045065771638088947558424515687624190113122357319209227560059859345335.
+Reading from /dev/fibonacci at offset 969, returned the sequence 14439042678085716960949814193344874389229173904390155479167035660686299132233394232110487256988461740058540821749323293504381921966930093689990678578706673205517616552290959865878623899352072116206415394.
+Reading from /dev/fibonacci at offset 968, returned the sequence 8923819140067279576517693617954321028440265607299555446060826481589224621166244735672823524716067936475357149422868654499935012664911951375780959510240885218998071071899153256478695309875487943652929941.
+Reading from /dev/fibonacci at offset 967, returned the sequence 5515223538018437384432120575390553360788908297090600033106209179097074511067149496437663732272393803583183672326454639004446909302018142314209719068465787986519545480391806609399928589476584172553485453.
+Reading from /dev/fibonacci at offset 966, returned the sequence 3408595602048842192085573042563767667651357310208955412954617302492150110099095239235159792443674132892173477096414015495488103362893809061571240441775097232478525591507346647078766720398903771099444488.
+Reading from /dev/fibonacci at offset 965, returned the sequence 2106627935969595192346547532826785693137550986881644620151591876604924400968054257202503939828719670691010195230040623508958805939124333252638478626690690754041019888884459962321161869077680401454040965.
+Reading from /dev/fibonacci at offset 964, returned the sequence 1301967666079246999739025509736981974513806323327310792803025425887225709131040982032655852614954462201163281866373391986529297423769475808932761815084406478437505702622886684757604851321223369645403523.
+Reading from /dev/fibonacci at offset 963, returned the sequence 804660269890348192607522023089803718623744663554333827348566450717698691837013275169848087213765208489846913363667231522429508515354857443705716811606284275603514186261573277563557017756457031808637442.
+Reading from /dev/fibonacci at offset 962, returned the sequence 497307396188898807131503486647178255890061659772976965454458975169527017294027706862807765401189253711316368502706160464099788908414618365227045003478122202833991516361313407194047833564766337836766081.
+Reading from /dev/fibonacci at offset 961, returned the sequence 307352873701449385476018536442625462733683003781356861894107475548171674542985568307040321812575954778530544860961071058329719606940239078478671808128162072769522669900259870369509184191690693971871361.
+Reading from /dev/fibonacci at offset 960, returned the sequence 189954522487449421655484950204552793156378655991620103560351499621355342751042138555767443588613298932785823641745089405770069301474379286748373195349960130064468846461053536824538649373075643864894720.
+Reading from /dev/fibonacci at offset 959, returned the sequence 117398351213999963820533586238072669577304347789736758333755975926816331791943429751272878223962655845744721219215981652559650305465859791730298612778201942705053823439206333544970534818615050106976641.
+Reading from /dev/fibonacci at offset 958, returned the sequence 72556171273449457834951363966480123579074308201883345226595523694539010959098708804494565364650643087041102422529107753210418996008519495018074582571758187359415023021847203279568114554460593757918079.
+Reading from /dev/fibonacci at offset 957, returned the sequence 44842179940550505985582222271592545998230039587853413107160452232277320832844720946778312859312012758703618796686873899349231309457340296712224030206443755345638800417359130265402420264154456349058562.
+Reading from /dev/fibonacci at offset 956, returned the sequence 27713991332898951849369141694887577580844268614029932119435071462261690126253987857716252505338630328337483625842233853861187686551179198305850552365314432013776222604488073014165694290306137408859517.
+Reading from /dev/fibonacci at offset 955, returned the sequence 17128188607651554136213080576704968417385770973823480987725380770015630706590733089062060353973382430366135170844640045488043622906161098406373477841129323331862577812871057251236725973848318940199045.
+Reading from /dev/fibonacci at offset 954, returned the sequence 10585802725247397713156061118182609163458497640206451131709690692246059419663254768654192151365247897971348454997593808373144063645018099899477074524185108681913644791617015762928968316457818468660472.
+Reading from /dev/fibonacci at offset 953, returned the sequence 6542385882404156423057019458522359253927273333617029856015690077769571286927478320407868202608134532394786715847046237114899559261142998506896403316944214649948933021254041488307757657390500471538573.
+Reading from /dev/fibonacci at offset 952, returned the sequence 4043416842843241290099041659660249909531224306589421275694000614476488132735776448246323948757113365576561739150547571258244504383875101392580671207240894031964711770362974274621210659067317997121899.
+Reading from /dev/fibonacci at offset 951, returned the sequence 2498969039560915132957977798862109344396049027027608580321689463293083154191701872161544253851021166818224976696498665856655054877267897114315732109703320617984221250891067213686546998323182474416674.
+Reading from /dev/fibonacci at offset 950, returned the sequence 1544447803282326157141063860798140565135175279561812695372311151183404978544074576084779694906092198758336762454048905401589449506607204278264939097537573413980490519471907060934663660744135522705225.
+Reading from /dev/fibonacci at offset 949, returned the sequence 954521236278588975816913938063968779260873747465795884949378312109678175647627296076764558944928968059888214242449760455065605370660692836050793012165747204003730731419160152751883337579046951711449.
+Reading from /dev/fibonacci at offset 948, returned the sequence 589926567003737181324149922734171785874301532096016810422932839073726802896447280008015135961163230698448548211599144946523844135946511442214146085371826209976759788052746908182780323165088570993776.
+Reading from /dev/fibonacci at offset 947, returned the sequence 364594669274851794492764015329796993386572215369779074526445473035951372751180016068749422983765737361439666030850615508541761234714181393836646926793920994026970943366413244569103014413958380717673.
+Reading from /dev/fibonacci at offset 946, returned the sequence 225331897728885386831385907404374792487729316726237735896487366037775430145267263939265712977397493337008882180748529437982082901232330048377499158577905215949788844686333663613677308751130190276103.
+Reading from /dev/fibonacci at offset 945, returned the sequence 139262771545966407661378107925422200898842898643541338629958106998175942605912752129483710006368244024430783850102086070559678333481851345459147768216015778077182098680079580955425705662828190441570.
+Reading from /dev/fibonacci at offset 944, returned the sequence 86069126182918979170007799478952591588886418082696397266529259039599487539354511809782002971029249312578098330646443367422404567750478702918351390361889437872606746006254082658251603088301999834533.
+Reading from /dev/fibonacci at offset 943, returned the sequence 53193645363047428491370308446469609309956480560844941363428847958576455066558240319701707035338994711852685519455642703137273765731372642540796377854126340204575352673825498297174102574526190607037.
+Reading from /dev/fibonacci at offset 942, returned the sequence 32875480819871550678637491032482982278929937521851455903100411081023032472796271490080295935690254600725412811190800664285130802019106060377555012507763097668031393332428584361077500513775809227496.
+Reading from /dev/fibonacci at offset 941, returned the sequence 20318164543175877812732817413986627031026543038993485460328436877553422593761968829621411099648740111127272708264842038852142963712266582163241365346363242536543959341396913936096602060750381379541.
+Reading from /dev/fibonacci at offset 940, returned the sequence 12557316276695672865904673618496355247903394482857970442771974203469609879034302660458884836041514489598140102925958625432987838306839478214313647161399855131487433991031670424980898453025427847955.
+Reading from /dev/fibonacci at offset 939, returned the sequence 7760848266480204946828143795490271783123148556135515017556462674083812714727666169162526263607225621529132605338883413419155125405427103948927718184963387405056525350365243511115703607724953531586.
+Reading from /dev/fibonacci at offset 938, returned the sequence 4796468010215467919076529823006083464780245926722455425215511529385797164306636491296358572434288868069007497587075212013832712901412374265385928976436467726430908640666426913865194845300474316369.
+Reading from /dev/fibonacci at offset 937, returned the sequence 2964380256264737027751613972484188318342902629413059592340951144698015550421029677866167691172936753460125107751808201405322412504014729683541789208526919678625616709698816597250508762424479215217.
+Reading from /dev/fibonacci at offset 936, returned the sequence 1832087753950730891324915850521895146437343297309395832874560384687781613885606813430190881261352114608882389835267010608510300397397644581844139767909548047805291930967610316614686082875995101152.
+Reading from /dev/fibonacci at offset 935, returned the sequence 1132292502314006136426698121962293171905559332103663759466390760010233936535422864435976809911584638851242717916541190796812112106617085101697649440617371630820324778731206280635822679548484114065.
+Reading from /dev/fibonacci at offset 934, returned the sequence 699795251636724754898217728559601974531783965205732073408169624677547677350183948994214071349767475757639671918725819811698188290780559480146490327292176416984967152236404035978863403327510987087.
+Reading from /dev/fibonacci at offset 933, returned the sequence 432497250677281381528480393402691197373775366897931686058221135332686259185238915441762738561817163093603045997815370985113923815836525621551159113325195213835357626494802244656959276220973126978.
+Reading from /dev/fibonacci at offset 932, returned the sequence 267298000959443373369737335156910777158008598307800387349948489344861418164945033552451332787950312664036625920910448826584264474944033858595331213966981203149609525741601791321904127106537860109.
+Reading from /dev/fibonacci at offset 931, returned the sequence 165199249717838008158743058245780420215766768590131298708272645987824841020293881889311405773866850429566420076904922158529659340892491762955827899358214010685748100753200453335055149114435266869.
+Reading from /dev/fibonacci at offset 930, returned the sequence 102098751241605365210994276911130356942241829717669088641675843357036577144651151663139927014083462234470205844005526668054605134051542095639503314608767192463861424988401337986848977992102593240.
+Reading from /dev/fibonacci at offset 929, returned the sequence 63100498476232642947748781334650063273524938872462210066596802630788263875642730226171478759783388195096214232899395490475054206840949667316324584749446818221886675764799115348206171122332673629.
+Reading from /dev/fibonacci at offset 928, returned the sequence 38998252765372722263245495576480293668716890845206878575079040726248313269008421436968448254300074039373991611106131177579550927210592428323178729859320374241974749223602222638642806869769919611.
+Reading from /dev/fibonacci at offset 927, returned the sequence 24102245710859920684503285758169769604808048027255331491517761904539950606634308789203030505483314155722222621793264312895503279630357238993145854890126443979911926541196892709563364252562754018.
+Reading from /dev/fibonacci at offset 926, returned the sequence 14896007054512801578742209818310524063908842817951547083561278821708362662374112647765417748816759883651768989312866864684047647580235189330032874969193930262062822682405329929079442617207165593.
+Reading from /dev/fibonacci at offset 925, returned the sequence 9206238656347119105761075939859245540899205209303784407956483082831587944260196141437612756666554272070453632480397448211455632050122049663112979920932513717849103858791562780483921635355588425.
+Reading from /dev/fibonacci at offset 924, returned the sequence 5689768398165682472981133878451278523009637608647762675604795738876774718113916506327804992150205611581315356832469416472592015530113139666919895048261416544213718823613767148595520981851577168.
+Reading from /dev/fibonacci at offset 923, returned the sequence 3516470258181436632779942061407967017889567600656021732351687343954813226146279635109807764516348660489138275647928031738863616520008909996193084872671097173635385035177795631888400653504011257.
+Reading from /dev/fibonacci at offset 922, returned the sequence 2173298139984245840201191817043311505120070007991740943253108394921961491967636871217997227633856951092177081184541384733728399010104229670726810175590319370578333788435971516707120328347565911.
+Reading from /dev/fibonacci at offset 921, returned the sequence 1343172118197190792578750244364655512769497592664280789098578949032851734178642763891810536882491709396961194463386647005135217509904680325466274697080777803057051246741824115181280325156445346.
+Reading from /dev/fibonacci at offset 920, returned the sequence 830126021787055047622441572678655992350572415327460154154529445889109757788994107326186690751365241695215886721154737728593181500199549345260535478509541567521282541694147401525840003191120565.
+Reading from /dev/fibonacci at offset 919, returned the sequence 513046096410135744956308671685999520418925177336820634944049503143741976389648656565623846131126467701745307742231909276542036009705130980205739218571236235535768705047676713655440321965324781.
+Reading from /dev/fibonacci at offset 918, returned the sequence 317079925376919302666132900992656471931647237990639519210479942745367781399345450760562844620238773993470578978922828452051145490494418365054796259938305331985513836646470687870399681225795784.
+Reading from /dev/fibonacci at offset 917, returned the sequence 195966171033216442290175770693343048487277939346181115733569560398374194990303205805061001510887693708274728763309080824490890519210712615150942958632930903550254868401206025785040640739528997.
+Reading from /dev/fibonacci at offset 916, returned the sequence 121113754343702860375957130299313423444369298644458403476910382346993586409042244955501843109351080285195850215613747627560254971283705749903853301305374428435258968245264662085359040486266787.
+Reading from /dev/fibonacci at offset 915, returned the sequence 74852416689513581914218640394029625042908640701722712256659178051380608581260960849559158401536613423078878547695333196930635547927006865247089657327556475114995900155941363699681600253262210.
+Reading from /dev/fibonacci at offset 914, returned the sequence 46261337654189278461738489905283798401460657942735691220251204295612977827781284105942684707814466862116971667918414430629619423356698884656763643977817953320263068089323298385677440233004577.
+Reading from /dev/fibonacci at offset 913, returned the sequence 28591079035324303452480150488745826641447982758987021036407973755767630753479676743616473693722146560961906879776918766301016124570307980590326013349738521794732832066618065314004160020257633.
+Reading from /dev/fibonacci at offset 912, returned the sequence 17670258618864975009258339416537971760012675183748670183843230539845347074301607362326211014092320301155064788141495664328603298786390904066437630628079431525530236022705233071673280212746944.
+Reading from /dev/fibonacci at offset 911, returned the sequence 10920820416459328443221811072207854881435307575238350852564743215922283679178069381290262679629826259806842091635423101972412825783917076523888382721659090269202596043912832242330879807510689.
+Reading from /dev/fibonacci at offset 910, returned the sequence 6749438202405646566036528344330116878577367608510319331278487323923063395123537981035948334462494041348222696506072562356190473002473827542549247906420341256327639978792400829342400405236255.
+Reading from /dev/fibonacci at offset 909, returned the sequence 4171382214053681877185282727877738002857939966728031521286255891999220284054531400254314345167332218458619395129350539616222352781443248981339134815238749012874956065120431412988479402274434.
+Reading from /dev/fibonacci at offset 908, returned the sequence 2578055988351964688851245616452378875719427641782287809992231431923843111069006580781633989295161822889603301376722022739968120221030578561210113091181592243452683913671969416353921002961821.
+Reading from /dev/fibonacci at offset 907, returned the sequence 1593326225701717188334037111425359127138512324945743711294024460075377172985524819472680355872170395569016093752628516876254232560412670420129021724057156769422272151448461996634558399312613.
+Reading from /dev/fibonacci at offset 906, returned the sequence 984729762650247500517208505027019748580915316836544098698206971848465938083481761308953633422991427320587207624093505863713887660617908141081091367124435474030411762223507419719362603649208.
+Reading from /dev/fibonacci at offset 905, returned the sequence 608596463051469687816828606398339378557597008109199612595817488226911234902043058163726722449178968248428886128535011012540344899794762279047930356932721295391860389224954576915195795663405.
+Reading from /dev/fibonacci at offset 904, returned the sequence 376133299598777812700379898628680370023318308727344486102389483621554703181438703145226910973812459072158321495558494851173542760823145862033161010191714178638551372998552842804166807985803.
+Reading from /dev/fibonacci at offset 903, returned the sequence 232463163452691875116448707769659008534278699381855126493428004605356531720604355018499811475366509176270564632976516161366802138971616417014769346741007116753309016226401734111028987677602.
+Reading from /dev/fibonacci at offset 902, returned the sequence 143670136146085937583931190859021361489039609345489359608961479016198171460834348126727099498445949895887756862581978689806740621851529445018391663450707061885242356772151108693137820308201.
+Reading from /dev/fibonacci at offset 901, returned the sequence 88793027306605937532517516910637647045239090036365766884466525589158360259770006891772711976920559280382807770394537471560061517120086971996377683290300054868066659454250625417891167369401.
+Reading from /dev/fibonacci at offset 900, returned the sequence 54877108839480000051413673948383714443800519309123592724494953427039811201064341234954387521525390615504949092187441218246679104731442473022013980160407007017175697317900483275246652938800.
+Reading from /dev/fibonacci at offset 899, returned the sequence 33915918467125937481103842962253932601438570727242174159971572162118549058705665656818324455395168664877858678207096253313382412388644498974363703129893047850890962136350142142644514430601.
+Reading from /dev/fibonacci at offset 898, returned the sequence 20961190372354062570309830986129781842361948581881418564523381264921262142358675578136063066130221950627090413980344964933296692342797974047650277030513959166284735181550341132602138508199.
+Reading from /dev/fibonacci at offset 897, returned the sequence 12954728094771874910794011976124150759076622145360755595448190897197286916346990078682261389264946714250768264226751288380085720045846524926713426099379088684606226954799801010042375922402.
+Reading from /dev/fibonacci at offset 896, returned the sequence 8006462277582187659515819010005631083285326436520662969075190367723975226011685499453801676865275236376322149753593676553210972296951449120936850931134870481678508226750540122559762585797.
+Reading from /dev/fibonacci at offset 895, returned the sequence 4948265817189687251278192966118519675791295708840092626373000529473311690335304579228459712399671477874446114473157611826874747748895075805776575168244218202927718728049260887482613336605.
+Reading from /dev/fibonacci at offset 894, returned the sequence 3058196460392500408237626043887111407494030727680570342702189838250663535676380920225341964465603758501876035280436064726336224548056373315160275762890652278750789498701279235077149249192.
+Reading from /dev/fibonacci at offset 893, returned the sequence 1890069356797186843040566922231408268297264981159522283670810691222648154658923659003117747934067719372570079192721547100538523200838702490616299405353565924176929229347981652405464087413.
+Reading from /dev/fibonacci at offset 892, returned the sequence 1168127103595313565197059121655703139196765746521048059031379147028015381017457261222224216531536039129305956087714517625797701347217670824543976357537086354573860269353297582671685161779.
+Reading from /dev/fibonacci at offset 891, returned the sequence 721942253201873277843507800575705129100499234638474224639431544194632773641466397780893531402531680243264123105007029474740821853621031666072323047816479569603068959994684069733778925634.
+Reading from /dev/fibonacci at offset 890, returned the sequence 446184850393440287353551321079998010096266511882573834391947602833382607375990863441330685129004358886041832982707488151056879493596639158471653309720606784970791309358613512937906236145.
+Reading from /dev/fibonacci at offset 889, returned the sequence 275757402808432990489956479495707119004232722755900390247483941361250166265475534339562846273527321357222290122299541323683942360024392507600669738095872784632277650636070556795872689489.
+Reading from /dev/fibonacci at offset 888, returned the sequence 170427447585007296863594841584290891092033789126673444144463661472132441110515329101767838855477037528819542860407946827372937133572246650870983571624734000338513658722542956142033546656.
+Reading from /dev/fibonacci at offset 887, returned the sequence 105329955223425693626361637911416227912198933629226946103020279889117725154960205237795007418050283828402747261891594496311005226452145856729686166471138784293763991913527600653839142833.
+Reading from /dev/fibonacci at offset 886, returned the sequence 65097492361581603237233203672874663179834855497446498041443381583014715955555123863972831437426753700416795598516352331061931907120100794141297405153595216044749666809015355488194403823.
+Reading from /dev/fibonacci at offset 885, returned the sequence 40232462861844090389128434238541564732364078131780448061576898306103009199405081373822175980623530127985951663375242165249073319332045062588388761317543568249014325104512245165644739010.
+Reading from /dev/fibonacci at offset 884, returned the sequence 24865029499737512848104769434333098447470777365666049979866483276911706756150042490150655456803223572430843935141110165812858587788055731552908643836051647795735341704503110322549664813.
+Reading from /dev/fibonacci at offset 883, returned the sequence 15367433362106577541023664804208466284893300766114398081710415029191302443255038883671520523820306555555107728234131999436214731543989331035480117481491920453278983400009134843095074197.
+Reading from /dev/fibonacci at offset 882, returned the sequence 9497596137630935307081104630124632162577476599551651898156068247720404312895003606479134932982917016875736206906978166376643856244066400517428526354559727342456358304493975479454590616.
+Reading from /dev/fibonacci at offset 881, returned the sequence 5869837224475642233942560174083834122315824166562746183554346781470898130360035277192385590837389538679371521327153833059570875299922930518051591126932193110822625095515159363640483581.
+Reading from /dev/fibonacci at offset 880, returned the sequence 3627758913155293073138544456040798040261652432988905714601721466249506182534968329286749342145527478196364685579824333317072980944143469999376935227627534231633733208978816115814107035.
+Reading from /dev/fibonacci at offset 879, returned the sequence 2242078311320349160804015718043036082054171733573840468952625315221391947825066947905636248691862060483006835747329499742497894355779460518674655899304658879188891886536343247826376546.
+Reading from /dev/fibonacci at offset 878, returned the sequence 1385680601834943912334528737997761958207480699415065245649096151028114234709901381381113093453665417713357849832494833574575086588364009480702279328322875352444841322442472867987730489.
+Reading from /dev/fibonacci at offset 877, returned the sequence 856397709485405248469486980045274123846691034158775223303529164193277713115165566524523155238196642769648985914834666167922807767415451037972376570981783526744050564093870379838646057.
+Reading from /dev/fibonacci at offset 876, returned the sequence 529282892349538663865041757952487834360789665256290022345566986834836521594735814856589938215468774943708863917660167406652278820948558442729902757341091825700790758348602488149084432.
+Reading from /dev/fibonacci at offset 875, returned the sequence 327114817135866584604445222092786289485901368902485200957962177358441191520429751667933217022727867825940121997174498761270528946466892595242473813640691701043259805745267891689561625.
+Reading from /dev/fibonacci at offset 874, returned the sequence 202168075213672079260596535859701544874888296353804821387604809476395330074306063188656721192740907117768741920485668645381749874481665847487428943700400124657530952603334596459522807.
+Reading from /dev/fibonacci at offset 873, returned the sequence 124946741922194505343848686233084744611013072548680379570357367882045861446123688479276495829986960708171380076688830115888779071985226747755044869940291576385728853141933295230038818.
+Reading from /dev/fibonacci at offset 872, returned the sequence 77221333291477573916747849626616800263875223805124441817247441594349468628182374709380225362753946409597361843796838529492970802496439099732384073760108548271802099461401301229483989.
+Reading from /dev/fibonacci at offset 871, returned the sequence 47725408630716931427100836606467944347137848743555937753109926287696392817941313769896270467233014298574018232891991586395808269488787648022660796180183028113926753680531994000554829.
+Reading from /dev/fibonacci at offset 870, returned the sequence 29495924660760642489647013020148855916737375061568504064137515306653075810241060939483954895520932111023343610904846943097162533007651451709723277579925520157875345780869307228929160.
+Reading from /dev/fibonacci at offset 869, returned the sequence 18229483969956288937453823586319088430400473681987433688972410981043317007700252830412315571712082187550674621987144643298645736481136196312937518600257507956051407899662686771625669.
+Reading from /dev/fibonacci at offset 868, returned the sequence 11266440690804353552193189433829767486336901379581070375165104325609758802540808109071639323808849923472668988917702299798516796526515255396785758979668012201823937881206620457303491.
+Reading from /dev/fibonacci at offset 867, returned the sequence 6963043279151935385260634152489320944063572302406363313807306655433558205159444721340676247903232264078005633069442343500128939954620940916151759620589495754227470018456066314322178.
+Reading from /dev/fibonacci at offset 866, returned the sequence 4303397411652418166932555281340446542273329077174707061357797670176200597381363387730963075905617659394663355848259956298387856571894314480633999359078516447596467862750554142981313.
+Reading from /dev/fibonacci at offset 865, returned the sequence 2659645867499517218328078871148874401790243225231656252449508985257357607778081333609713171997614604683342277221182387201741083382726626435517760261510979306631002155705512171340865.
+Reading from /dev/fibonacci at offset 864, returned the sequence 1643751544152900948604476410191572140483085851943050808908288684918842989603282054121249903908003054711321078627077569096646773189167688045116239097567537140965465707045041971640448.
+Reading from /dev/fibonacci at offset 863, returned the sequence 1015894323346616269723602460957302261307157373288605443541220300338514618174799279488463268089611549972021198594104818105094310193558938390401521163943442165665536448660470199700417.
+Reading from /dev/fibonacci at offset 862, returned the sequence 627857220806284678880873949234269879175928478654445365367068384580328371428482774632786635818391504739299880032972750991552462995608749654714717933624094975299929258384571771940031.
+Reading from /dev/fibonacci at offset 861, returned the sequence 388037102540331590842728511723032382131228894634160078174151915758186246746316504855676632271220045232721318561132067113541847197950188735686803230319347190365607190275898427760386.
+Reading from /dev/fibonacci at offset 860, returned the sequence 239820118265953088038145437511237497044699584020285287192916468822142124682166269777110003547171459506578561471840683878010615797658560919027914703304747784934322068108673344179645.
+Reading from /dev/fibonacci at offset 859, returned the sequence 148216984274378502804583074211794885086529310613874790981235446936044122064150235078566628724048585726142757089291383235531231400291627816658888527014599405431285122167225083580741.
+Reading from /dev/fibonacci at offset 858, returned the sequence 91603133991574585233562363299442611958170273406410496211681021886098002618016034698543374823122873780435804382549300642479384397366933102369026176290148379503036945941448260598904.
+Reading from /dev/fibonacci at offset 857, returned the sequence 56613850282803917571020710912352273128359037207464294769554425049946119446134200380023253900925711945706952706742082593051847002924694714289862350724451025928248176225776822981837.
+Reading from /dev/fibonacci at offset 856, returned the sequence 34989283708770667662541652387090338829811236198946201442126596836151883171881834318520120922197161834728851675807218049427537394442238388079163825565697353574788769715671437617067.
+Reading from /dev/fibonacci at offset 855, returned the sequence 21624566574033249908479058525261934298547801008518093327427828213794236274252366061503132978728550110978101030934864543624309608482456326210698525158753672353459406510105385364770.
+Reading from /dev/fibonacci at offset 854, returned the sequence 13364717134737417754062593861828404531263435190428108114698768622357646897629468257016987943468611723750750644872353505803227785959782061868465300406943681221329363205566052252297.
+Reading from /dev/fibonacci at offset 853, returned the sequence 8259849439295832154416464663433529767284365818089985212729059591436589376622897804486145035259938387227350386062511037821081822522674264342233224751809991132130043304539333112473.
+Reading from /dev/fibonacci at offset 852, returned the sequence 5104867695441585599646129198394874763979069372338122901969709030921057521006570452530842908208673336523400258809842467982145963437107797526232075655133690089199319901026719139824.
+Reading from /dev/fibonacci at offset 851, returned the sequence 3154981743854246554770335465038655003305296445751862310759350560515531855616327351955302127051265050703950127252668569838935859085566466816001149096676301042930723403512613972649.
+Reading from /dev/fibonacci at offset 850, returned the sequence 1949885951587339044875793733356219760673772926586260591210358470405525665390243100575540781157408285819450131557173898143210104351541330710230926558457389046268596497514105167175.
+Reading from /dev/fibonacci at offset 849, returned the sequence 1205095792266907509894541731682435242631523519165601719548992090110006190226084251379761345893856764884499995695494671695725754734025136105770222538218911996662126905998508805474.
+Reading from /dev/fibonacci at offset 848, returned the sequence 744790159320431534981252001673784518042249407420658871661366380295519475164158849195779435263551520934950135861679226447484349617516194604460704020238477049606469591515596361701.
+Reading from /dev/fibonacci at offset 847, returned the sequence 460305632946475974913289730008650724589274111744942847887625709814486715061925402183981910630305243949549859833815445248241405116508941501309518517980434947055657314482912443773.
+Reading from /dev/fibonacci at offset 846, returned the sequence 284484526373955560067962271665133793452975295675716023773740670481032760102233447011797524633246276985400276027863781199242944501007253103151185502258042102550812277032683917928.
+Reading from /dev/fibonacci at offset 845, returned the sequence 175821106572520414845327458343516931136298816069226824113885039333453954959691955172184385997058966964149583805951664048998460615501688398158333015722392844504845037450228525845.
+Reading from /dev/fibonacci at offset 844, returned the sequence 108663419801435145222634813321616862316676479606489199659855631147578805142541491839613138636187310021250692221912117150244483885505564704992852486535649258045967239582455392083.
+Reading from /dev/fibonacci at offset 843, returned the sequence 67157686771085269622692645021900068819622336462737624454029408185875149817150463332571247360871656942898891584039546898753976729996123693165480529186743586458877797867773133762.
+Reading from /dev/fibonacci at offset 842, returned the sequence 41505733030349875599942168299716793497054143143751575205826222961703655325391028507041891275315653078351800637872570251490507155509441011827371957348905671587089441714682258321.
+Reading from /dev/fibonacci at offset 841, returned the sequence 25651953740735394022750476722183275322568193318986049248203185224171494491759434825529356085556003864547090946166976647263469574486682681338108571837837914871788356153090875441.
+Reading from /dev/fibonacci at offset 840, returned the sequence 15853779289614481577191691577533518174485949824765525957623037737532160833631593681512535189759649213804709691705593604227037581022758330489263385511067756715301085561591382880.
+Reading from /dev/fibonacci at offset 839, returned the sequence 9798174451120912445558785144649757148082243494220523290580147486639333658127841144016820895796354650742381254461383043036431993463924350848845186326770158156487270591499492561.
+Reading from /dev/fibonacci at offset 838, returned the sequence 6055604838493569131632906432883761026403706330545002667042890250892827175503752537495714293963294563062328437244210561190605587558833979640418199184297598558813814970091890319.
+Reading from /dev/fibonacci at offset 837, returned the sequence 3742569612627343313925878711765996121678537163675520623537257235746506482624088606521106601833060087680052817217172481845826405905090371208426987142472559597673455621407602242.
+Reading from /dev/fibonacci at offset 836, returned the sequence 2313035225866225817707027721117764904725169166869482043505633015146320692879663930974607692130234475382275620027038079344779181653743608431991212041825038961140359348684288077.
+Reading from /dev/fibonacci at offset 835, returned the sequence 1429534386761117496218850990648231216953367996806038580031624220600185789744424675546498909702825612297777197190134402501047224251346762776435775100647520636533096272723314165.
+Reading from /dev/fibonacci at offset 834, returned the sequence 883500839105108321488176730469533687771801170063443463474008794546134903135239255428108782427408863084498422836903676843731957402396845655555436941177518324607263075960973912.
+Reading from /dev/fibonacci at offset 833, returned the sequence 546033547656009174730674260178697529181566826742595116557615426054050886609185420118390127275416749213278774353230725657315266848949917120880338159470002311925833196762340253.
+Reading from /dev/fibonacci at offset 832, returned the sequence 337467291449099146757502470290836158590234343320848346916393368492084016526053835309718655151992113871219648483672951186416690553446928534675098781707516012681429879198633659.
+Reading from /dev/fibonacci at offset 831, returned the sequence 208566256206910027973171789887861370591332483421746769641222057561966870083131584808671472123424635342059125869557774470898576295502988586205239377762486299244403317563706594.
+Reading from /dev/fibonacci at offset 830, returned the sequence 128901035242189118784330680402974787998901859899101577275171310930117146442922250501047183028567478529160522614115176715518114257943939948469859403945029713437026561634927065.
+Reading from /dev/fibonacci at offset 829, returned the sequence 79665220964720909188841109484886582592430623522645192366050746631849723640209334307624289094857156812898603255442597755380462037559048637735379973817456585807376755928779529.
+Reading from /dev/fibonacci at offset 828, returned the sequence 49235814277468209595489570918088205406471236376456384909120564298267422802712916193422893933710321716261919358672578960137652220384891310734479430127573127629649805706147536.
+Reading from /dev/fibonacci at offset 827, returned the sequence 30429406687252699593351538566798377185959387146188807456930182333582300837496418114201395161146835096636683896770018795242809817174157327000900543689883458177726950222631993.
+Reading from /dev/fibonacci at offset 826, returned the sequence 18806407590215510002138032351289828220511849230267577452190381964685121965216498079221498772563486619625235461902560164894842403210733983733578886437689669451922855483515543.
+Reading from /dev/fibonacci at offset 825, returned the sequence 11622999097037189591213506215508548965447537915921230004739800368897178872279920034979896388583348477011448434867458630347967413963423343267321657252193788725804094739116450.
+Reading from /dev/fibonacci at offset 824, returned the sequence 7183408493178320410924526135781279255064311314346347447450581595787943092936578044241602383980138142613787027035101534546874989247310640466257229185495880726118760744399093.
+Reading from /dev/fibonacci at offset 823, returned the sequence 4439590603858869180288980079727269710383226601574882557289218773109235779343341990738294004603210334397661407832357095801092424716112702801064428066697907999685333994717357.
+Reading from /dev/fibonacci at offset 822, returned the sequence 2743817889319451230635546056054009544681084712771464890161362822678707313593236053503308379376927808216125619202744438745782564531197937665192801118797972726433426749681736.
+Reading from /dev/fibonacci at offset 821, returned the sequence 1695772714539417949653434023673260165702141888803417667127855950430528465750105937234985625226282526181535788629612657055309860184914765135871626947899935273251907245035621.
+Reading from /dev/fibonacci at offset 820, returned the sequence 1048045174780033280982112032380749378978942823968047223033506872248178847843130116268322754150645282034589830573131781690472704346283172529321174170898037453181519504646115.
+Reading from /dev/fibonacci at offset 819, returned the sequence 647727539759384668671321991292510786723199064835370444094349078182349617906975820966662871075637244146945958056480875364837155838631592606550452777001897820070387740389506.
+Reading from /dev/fibonacci at offset 818, returned the sequence 400317635020648612310790041088238592255743759132676778939157794065829229936154295301659883075008037887643872516650906325635548507651579922770721393896139633111131764256609.
+Reading from /dev/fibonacci at offset 817, returned the sequence 247409904738736056360531950204272194467455305702693665155191284116520387970821525665002988000629206259302085539829969039201607330980012683779731383105758186959255976132897.
+Reading from /dev/fibonacci at offset 816, returned the sequence 152907730281912555950258090883966397788288453429983113783966509949308841965332769636656895074378831628341786976820937286433941176671567238990990010790381446151875788123712.
+Reading from /dev/fibonacci at offset 815, returned the sequence 94502174456823500410273859320305796679166852272710551371224774167211546005488756028346092926250374630960298563009031752767666154308445444788741372315376740807380188009185.
+Reading from /dev/fibonacci at offset 814, returned the sequence 58405555825089055539984231563660601109121601157272562412741735782097295959844013608310802148128456997381488413811905533666275022363121794202248638475004705344495600114527.
+Reading from /dev/fibonacci at offset 813, returned the sequence 36096618631734444870289627756645195570045251115437988958483038385114250045644742420035290778121917633578810149197126219101391131945323650586492733840372035462884587894658.
+Reading from /dev/fibonacci at offset 812, returned the sequence 22308937193354610669694603807015405539076350041834573454258697396983045914199271188275511370006539363802678264614779314564883890417798143615755904634632669881611012219869.
+Reading from /dev/fibonacci at offset 811, returned the sequence 13787681438379834200595023949629790030968901073603415504224340988131204131445471231759779408115378269776131884582346904536507241527525506970736829205739365581273575674789.
+Reading from /dev/fibonacci at offset 810, returned the sequence 8521255754974776469099579857385615508107448968231157950034356408851841782753799956515731961891161094026546380032432410028376648890272636645019075428893304300337436545080.
+Reading from /dev/fibonacci at offset 809, returned the sequence 5266425683405057731495444092244174522861452105372257554189984579279362348691671275244047446224217175749585504549914494508130592637252870325717753776846061280936139129709.
+Reading from /dev/fibonacci at offset 808, returned the sequence 3254830071569718737604135765141440985245996862858900395844371829572479434062128681271684515666943918276960875482517915520246056253019766319301321652047243019401297415371.
+Reading from /dev/fibonacci at offset 807, returned the sequence 2011595611835338993891308327102733537615455242513357158345612749706882914629542593972362930557273257472624629067396578987884536384233104006416432124798818261534841714338.
+Reading from /dev/fibonacci at offset 806, returned the sequence 1243234459734379743712827438038707447630541620345543237498759079865596519432586087299321585109670660804336246415121336532361519868786662312884889527248424757866455701033.
+Reading from /dev/fibonacci at offset 805, returned the sequence 768361152100959250178480889064026089984913622167813920846853669841286395196956506673041345447602596668288382652275242455523016515446441693531542597550393503668386013305.
+Reading from /dev/fibonacci at offset 804, returned the sequence 474873307633420493534346548974681357645627998177729316651905410024310124235629580626280239662068064136047863762846094076838503353340220619353346929698031254198069687728.
+Reading from /dev/fibonacci at offset 803, returned the sequence 293487844467538756644134340089344732339285623990084604194948259816976270961326926046761105785534532532240518889429148378684513162106221074178195667852362249470316325577.
+Reading from /dev/fibonacci at offset 802, returned the sequence 181385463165881736890212208885336625306342374187644712456957150207333853274302654579519133876533531603807344873416945698153990191233999545175151261845669004727753362151.
+Reading from /dev/fibonacci at offset 801, returned the sequence 112102381301657019753922131204008107032943249802439891737991109609642417687024271467241971909001000928433174016012202680530522970872221529003044406006693244742562963426.
+Reading from /dev/fibonacci at offset 800, returned the sequence 69283081864224717136290077681328518273399124385204820718966040597691435587278383112277161967532530675374170857404743017623467220361778016172106855838975759985190398725.
+Reading from /dev/fibonacci at offset 799, returned the sequence 42819299437432302617632053522679588759544125417235071019025069011950982099745888354964809941468470253059003158607459662907055750510443512830937550167717484757372564701.
+Reading from /dev/fibonacci at offset 798, returned the sequence 26463782426792414518658024158648929513854998967969749699940971585740453487532494757312352026064060422315167698797283354716411469851334503341169305671258275227817834024.
+Reading from /dev/fibonacci at offset 797, returned the sequence 16355517010639888098974029364030659245689126449265321319084097426210528612213393597652457915404409830743835459810176308190644280659109009489768244496459209529554730677.
+Reading from /dev/fibonacci at offset 796, returned the sequence 10108265416152526419683994794618270268165872518704428380856874159529924875319101159659894110659650591571332238987107046525767189192225493851401061174799065698263103347.
+Reading from /dev/fibonacci at offset 795, returned the sequence 6247251594487361679290034569412388977523253930560892938227223266680603736894292437992563804744759239172503220823069261664877091466883515638367183321660143831291627330.
+Reading from /dev/fibonacci at offset 794, returned the sequence 3861013821665164740393960225205881290642618588143535442629650892849321138424808721667330305914891352398829018164037784860890097725341978213033877853138921866971476017.
+Reading from /dev/fibonacci at offset 793, returned the sequence 2386237772822196938896074344206507686880635342417357495597572373831282598469483716325233498829867886773674202659031476803986993741541537425333305468521221964320151313.
+Reading from /dev/fibonacci at offset 792, returned the sequence 1474776048842967801497885880999373603761983245726177947032078519018038539955325005342096807085023465625154815505006308056903103983800440787700572384617699902651324704.
+Reading from /dev/fibonacci at offset 791, returned the sequence 911461723979229137398188463207134083118652096691179548565493854813244058514158710983136691744844421148519387154025168747083889757741096637632733083903522061668826609.
+Reading from /dev/fibonacci at offset 790, returned the sequence 563314324863738664099697417792239520643331149034998398466584664204794481441166294358960115340179044476635428350981139309819214226059344150067839300714177840982498095.
+Reading from /dev/fibonacci at offset 789, returned the sequence 348147399115490473298491045414894562475320947656181150098909190608449577072992416624176576404665376671883958803044029437264675531681752487564893783189344220686328514.
+Reading from /dev/fibonacci at offset 788, returned the sequence 215166925748248190801206372377344958168010201378817248367675473596344904368173877734783538935513667804751469547937109872554538694377591662502945517524833620296169581.
+Reading from /dev/fibonacci at offset 787, returned the sequence 132980473367242282497284673037549604307310746277363901731233717012104672704818538889393037469151708867132489255106919564710136837304160825061948265664510600390158933.
+Reading from /dev/fibonacci at offset 786, returned the sequence 82186452381005908303921699339795353860699455101453346636441756584240231663355338845390501466361958937618980292830190307844401857073430837440997251860323019906010648.
+Reading from /dev/fibonacci at offset 785, returned the sequence 50794020986236374193362973697754250446611291175910555094791960427864441041463200044002536002789749929513508962276729256865734980230729987620951013804187580484148285.
+Reading from /dev/fibonacci at offset 784, returned the sequence 31392431394769534110558725642041103414088163925542791541649796156375790621892138801387965463572209008105471330553461050978666876842700849820046238056135439421862363.
+Reading from /dev/fibonacci at offset 783, returned the sequence 19401589591466840082804248055713147032523127250367763553142164271488650419571061242614570539217540921408037631723268205887068103388029137800904775748052141062285922.
+Reading from /dev/fibonacci at offset 782, returned the sequence 11990841803302694027754477586327956381565036675175027988507631884887140202321077558773394924354668086697433698830192845091598773454671712019141462308083298359576441.
+Reading from /dev/fibonacci at offset 781, returned the sequence 7410747788164146055049770469385190650958090575192735564634532386601510217249983683841175614862872834710603932893075360795469329933357425781763313439968842702709481.
+Reading from /dev/fibonacci at offset 780, returned the sequence 4580094015138547972704707116942765730606946099982292423873099498285629985071093874932219309491795251986829765937117484296129443521314286237378148868114455656866960.
+Reading from /dev/fibonacci at offset 779, returned the sequence 2830653773025598082345063352442424920351144475210443140761432888315880232178889808908956305371077582723774166955957876499339886412043139544385164571854387045842521.
+Reading from /dev/fibonacci at offset 778, returned the sequence 1749440242112949890359643764500340810255801624771849283111666609969749752892204066023263004120717669263055598981159607796789557109271146692992984296260068611024439.
+Reading from /dev/fibonacci at offset 777, returned the sequence 1081213530912648191985419587942084110095342850438593857649766278346130479286685742885693301250359913460718567974798268702550329302771992851392180275594318434818082.
+Reading from /dev/fibonacci at offset 776, returned the sequence 668226711200301698374224176558256700160458774333255425461900331623619273605518323137569702870357755802337031006361339094239227806499153841600804020665750176206357.
+Reading from /dev/fibonacci at offset 775, returned the sequence 412986819712346493611195411383827409934884076105338432187865946722511205681167419748123598380002157658381536968436929608311101496272839009791376254928568258611725.
+Reading from /dev/fibonacci at offset 774, returned the sequence 255239891487955204763028765174429290225574698227916993274034384901108067924350903389446104490355598143955494037924409485928126310226314831809427765737181917594632.
+Reading from /dev/fibonacci at offset 773, returned the sequence 157746928224391288848166646209398119709309377877421438913831561821403137756816516358677493889646559514426042930512520122382975186046524177981948489191386341017093.
+Reading from /dev/fibonacci at offset 772, returned the sequence 97492963263563915914862118965031170516265320350495554360202823079704930167534387030768610600709038629529451107411889363545151124179790653827479276545795576577539.
+Reading from /dev/fibonacci at offset 771, returned the sequence 60253964960827372933304527244366949193044057526925884553628738741698207589282129327908883288937520884896591823100630758837824061866733524154469212645590764439554.
+Reading from /dev/fibonacci at offset 770, returned the sequence 37238998302736542981557591720664221323221262823569669806574084338006722578252257702859727311771517744632859284311258604707327062313057129673010063900204812137985.
+Reading from /dev/fibonacci at offset 769, returned the sequence 23014966658090829951746935523702727869822794703356214747054654403691485011029871625049155977166003140263732538789372154130496999553676394481459148745385952301569.
+Reading from /dev/fibonacci at offset 768, returned the sequence 14224031644645713029810656196961493453398468120213455059519429934315237567222386077810571334605514604369126745521886450576830062759380735191550915154818859836416.
+Reading from /dev/fibonacci at offset 767, returned the sequence 8790935013445116921936279326741234416424326583142759687535224469376247443807485547238584642560488535894605793267485703553666936794295659289908233590567092465153.
+Reading from /dev/fibonacci at offset 766, returned the sequence 5433096631200596107874376870220259036974141537070695371984205464938990123414900530571986692045026068474520952254400747023163125965085075901642681564251767371263.
+Reading from /dev/fibonacci at offset 765, returned the sequence 3357838382244520814061902456520975379450185046072064315551019004437257320392585016666597950515462467420084841013084956530503810829210583388265552026315325093890.
+Reading from /dev/fibonacci at offset 764, returned the sequence 2075258248956075293812474413699283657523956490998631056433186460501732803022315513905388741529563601054436111241315790492659315135874492513377129537936442277373.
+Reading from /dev/fibonacci at offset 763, returned the sequence 1282580133288445520249428042821691721926228555073433259117832543935524517370269502761209208985898866365648729771769166037844495693336090874888422488378882816517.
+Reading from /dev/fibonacci at offset 762, returned the sequence 792678115667629773563046370877591935597727935925197797315353916566208285652046011144179532543664734688787381469546624454814819442538401638488707049557559460856.
+Reading from /dev/fibonacci at offset 761, returned the sequence 489902017620815746686381671944099786328500619148235461802478627369316231718223491617029676442234131676861348302222541583029676250797689236399715438821323355661.
+Reading from /dev/fibonacci at offset 760, returned the sequence 302776098046814026876664698933492149269227316776962335512875289196892053933822519527149856101430603011926033167324082871785143191740712402088991610736236105195.
+Reading from /dev/fibonacci at offset 759, returned the sequence 187125919574001719809716973010607637059273302371273126289603338172424177784400972089879820340803528664935315134898458711244533059056976834310723828085087250466.
+Reading from /dev/fibonacci at offset 758, returned the sequence 115650178472812307066947725922884512209954014405689209223271951024467876149421547437270035760627074346990718032425624160540610132683735567778267782651148854729.
+Reading from /dev/fibonacci at offset 757, returned the sequence 71475741101189412742769247087723124849319287965583917066331387147956301634979424652609784580176454317944597102472834550703922926373241266532456045433938395737.
+Reading from /dev/fibonacci at offset 756, returned the sequence 44174437371622894324178478835161387360634726440105292156940563876511574514442122784660251180450620029046120929952789609836687206310494301245811737217210458992.
+Reading from /dev/fibonacci at offset 755, returned the sequence 27301303729566518418590768252561737488684561525478624909390823271444727120537301867949533399725834288898476172520044940867235720062746965286644308216727936745.
+Reading from /dev/fibonacci at offset 754, returned the sequence 16873133642056375905587710582599649871950164914626667247549740605066847393904820916710717780724785740147644757432744668969451486247747335959167429000482522247.
+Reading from /dev/fibonacci at offset 753, returned the sequence 10428170087510142513003057669962087616734396610851957661841082666377879726632480951238815619001048548750831415087300271897784233814999629327476879216245414498.
+Reading from /dev/fibonacci at offset 752, returned the sequence 6444963554546233392584652912637562255215768303774709585708657938688967667272339965471902161723737191396813342345444397071667252432747706631690549784237107749.
+Reading from /dev/fibonacci at offset 751, returned the sequence 3983206532963909120418404757324525361518628307077248076132424727688912059360140985766913457277311357354018072741855874826116981382251922695786329432008306749.
+Reading from /dev/fibonacci at offset 750, returned the sequence 2461757021582324272166248155313036893697139996697461509576233211000055607912198979704988704446425834042795269603588522245550271050495783935904220352228801000.
+Reading from /dev/fibonacci at offset 749, returned the sequence 1521449511381584848252156602011488467821488310379786566556191516688856451447942006061924752830885523311222803138267352580566710331756138759882109079779505749.
+Reading from /dev/fibonacci at offset 748, returned the sequence 940307510200739423914091553301548425875651686317674943020041694311199156464256973643063951615540310731572466465321169664983560718739645176022111272449295251.
+Reading from /dev/fibonacci at offset 747, returned the sequence 581142001180845424338065048709940041945836624062111623536149822377657294983685032418860801215345212579650336672946182915583149613016493583859997807330210498.
+Reading from /dev/fibonacci at offset 746, returned the sequence 359165509019893999576026504591608383929815062255563319483891871933541861480571941224203150400195098151922129792374986749400411105723151592162113465119084753.
+Reading from /dev/fibonacci at offset 745, returned the sequence 221976492160951424762038544118331658016021561806548304052257950444115433503113091194657650815150114427728206880571196166182738507293341991697884342211125745.
+Reading from /dev/fibonacci at offset 744, returned the sequence 137189016858942574813987960473276725913793500449015015431633921489426427977458850029545499585044983724193922911803790583217672598429809600464229122907959008.
+Reading from /dev/fibonacci at offset 743, returned the sequence 84787475302008849948050583645054932102228061357533288620624028954689005525654241165112151230105130703534283968767405582965065908863532391233655219303166737.
+Reading from /dev/fibonacci at offset 742, returned the sequence 52401541556933724865937376828221793811565439091481726811009892534737422451804608864433348354939853020659638943036385000252606689566277209230573903604792271.
+Reading from /dev/fibonacci at offset 741, returned the sequence 32385933745075125082113206816833138290662622266051561809614136419951583073849632300678802875165277682874645025731020582712459219297255182003081315698374466.
+Reading from /dev/fibonacci at offset 740, returned the sequence 20015607811858599783824170011388655520902816825430165001395756114785839377954976563754545479774575337784993917305364417540147470269022027227492587906417805.
+Reading from /dev/fibonacci at offset 739, returned the sequence 12370325933216525298289036805444482769759805440621396808218380305165743695894655736924257395390702345089651108425656165172311749028233154775588727791956661.
+Reading from /dev/fibonacci at offset 738, returned the sequence 7645281878642074485535133205944172751143011384808768193177375809620095682060320826830288084383872992695342808879708252367835721240788872451903860114461144.
+Reading from /dev/fibonacci at offset 737, returned the sequence 4725044054574450812753903599500310018616794055812628615041004495545648013834334910093969311006829352394308299545947912804476027787444282323684867677495517.
+Reading from /dev/fibonacci at offset 736, returned the sequence 2920237824067623672781229606443862732526217328996139578136371314074447668225985916736318773377043640301034509333760339563359693453344590128218992436965627.
+Reading from /dev/fibonacci at offset 735, returned the sequence 1804806230506827139972673993056447286090576726816489036904633181471200345608348993357650537629785712093273790212187573241116334334099692195465875240529890.
+Reading from /dev/fibonacci at offset 734, returned the sequence 1115431593560796532808555613387415446435640602179650541231738132603247322617636923378668235747257928207760719121572766322243359119244897932753117196435737.
+Reading from /dev/fibonacci at offset 733, returned the sequence 689374636946030607164118379669031839654936124636838495672895048867953022990712069978982301882527783885513071090614806918872975214854794262712758044094153.
+Reading from /dev/fibonacci at offset 732, returned the sequence 426056956614765925644437233718383606780704477542812045558843083735294299626924853399685933864730144322247648030957959403370383904390103670040359152341584.
+Reading from /dev/fibonacci at offset 731, returned the sequence 263317680331264681519681145950648232874231647094026450114051965132658723363787216579296368017797639563265423059656847515502591310464690592672398891752569.
+Reading from /dev/fibonacci at offset 730, returned the sequence 162739276283501244124756087767735373906472830448785595444791118602635576263137636820389565846932504758982224971301111887867792593925413077367960260589015.
+Reading from /dev/fibonacci at offset 729, returned the sequence 100578404047763437394925058182912858967758816645240854669260846530023147100649579758906802170865134804283198088355735627634798716539277515304438631163554.
+Reading from /dev/fibonacci at offset 728, returned the sequence 62160872235737806729831029584822514938714013803544740775530272072612429162488057061482763676067369954699026882945376260232993877386135562063521629425461.
+Reading from /dev/fibonacci at offset 727, returned the sequence 38417531812025630665094028598090344029044802841696113893730574457410717938161522697424038494797764849584171205410359367401804839153141953240917001738093.
+Reading from /dev/fibonacci at offset 726, returned the sequence 23743340423712176064737000986732170909669210961848626881799697615201711224326534364058725181269605105114855677535016892831189038232993608822604627687368.
+Reading from /dev/fibonacci at offset 725, returned the sequence 14674191388313454600357027611358173119375591879847487011930876842209006713834988333365313313528159744469315527875342474570615800920148344418312374050725.
+Reading from /dev/fibonacci at offset 724, returned the sequence 9069149035398721464379973375373997790293619082001139869868820772992704510491546030693411867741445360645540149659674418260573237312845264404292253636643.
+Reading from /dev/fibonacci at offset 723, returned the sequence 5605042352914733135977054235984175329081972797846347142062056069216302203343442302671901445786714383823775378215668056310042563607303080014020120414082.
+Reading from /dev/fibonacci at offset 722, returned the sequence 3464106682483988328402919139389822461211646284154792727806764703776402307148103728021510421954730976821764771444006361950530673705542184390272133222561.
+Reading from /dev/fibonacci at offset 721, returned the sequence 2140935670430744807574135096594352867870326513691554414255291365439899896195338574650391023831983407002010606771661694359511889901760895623747987191521.
+Reading from /dev/fibonacci at offset 720, returned the sequence 1323171012053243520828784042795469593341319770463238313551473338336502410952765153371119398122747569819754164672344667591018783803781288766524146031040.
+Reading from /dev/fibonacci at offset 719, returned the sequence 817764658377501286745351053798883274529006743228316100703818027103397485242573421279271625709235837182256442099317026768493106097979606857223841160481.
+Reading from /dev/fibonacci at offset 718, returned the sequence 505406353675742234083432988996586318812313027234922212847655311233104925710191732091847772413511732637497722573027640822525677705801681909300304870559.
+Reading from /dev/fibonacci at offset 717, returned the sequence 312358304701759052661918064802296955716693715993393887856162715870292559532381689187423853295724104544758719526289385945967428392177924947923536289922.
+Reading from /dev/fibonacci at offset 716, returned the sequence 193048048973983181421514924194289363095619311241528324991492595362812366177810042904423919117787628092739003046738254876558249313623756961376768580637.
+Reading from /dev/fibonacci at offset 715, returned the sequence 119310255727775871240403140608007592621074404751865562864670120507480193354571646282999934177936476452019716479551131069409179078554167986546767709285.
+Reading from /dev/fibonacci at offset 714, returned the sequence 73737793246207310181111783586281770474544906489662762126822474855332172823238396621423984939851151640719286567187123807149070235069588974830000871352.
+Reading from /dev/fibonacci at offset 713, returned the sequence 45572462481568561059291357021725822146529498262202800737847645652148020531333249661575949238085324811300429912364007262260108843484579011716766837933.
+Reading from /dev/fibonacci at offset 712, returned the sequence 28165330764638749121820426564555948328015408227459961388974829203184152291905146959848035701765826829418856654823116544888961391585009963113234033419.
+Reading from /dev/fibonacci at offset 711, returned the sequence 17407131716929811937470930457169873818514090034742839348872816448963868239428102701727913536319497981881573257540890717371147451899569048603532804514.
+Reading from /dev/fibonacci at offset 710, returned the sequence 10758199047708937184349496107386074509501318192717122040102012754220284052477044258120122165446328847537283397282225827517813939685440914509701228905.
+Reading from /dev/fibonacci at offset 709, returned the sequence 6648932669220874753121434349783799309012771842025717308770803694743584186951058443607791370873169134344289860258664889853333512214128134093831575609.
+Reading from /dev/fibonacci at offset 708, returned the sequence 4109266378488062431228061757602275200488546350691404731331209059476699865525985814512330794573159713192993537023560937664480427471312780415869653296.
+Reading from /dev/fibonacci at offset 707, returned the sequence 2539666290732812321893372592181524108524225491334312577439594635266884321425072629095460576300009421151296323235103952188853084742815353677961922313.
+Reading from /dev/fibonacci at offset 706, returned the sequence 1569600087755250109334689165420751091964320859357092153891614424209815544100913185416870218273150292041697213788456985475627342728497426737907730983.
+Reading from /dev/fibonacci at offset 705, returned the sequence 970066202977562212558683426760773016559904631977220423547980211057068777324159443678590358026859129109599109446646966713225742014317926940054191330.
+Reading from /dev/fibonacci at offset 704, returned the sequence 599533884777687896776005738659978075404416227379871730343634213152746766776753741738279860246291162932098104341810018762401600714179499797853539653.
+Reading from /dev/fibonacci at offset 703, returned the sequence 370532318199874315782677688100794941155488404597348693204345997904322010547405701940310497780567966177501005104836947950824141300138427142200651677.
+Reading from /dev/fibonacci at offset 702, returned the sequence 229001566577813580993328050559183134248927822782523037139288215248424756229348039797969362465723196754597099236973070811577459414041072655652887976.
+Reading from /dev/fibonacci at offset 701, returned the sequence 141530751622060734789349637541611806906560581814825656065057782655897254318057662142341135314844769422903905867863877139246681886097354486547763701.
+Reading from /dev/fibonacci at offset 700, returned the sequence 87470814955752846203978413017571327342367240967697381074230432592527501911290377655628227150878427331693193369109193672330777527943718169105124275.
+Reading from /dev/fibonacci at offset 699, returned the sequence 54059936666307888585371224524040479564193340847128274990827350063369752406767284486712908163966342091210712498754683466915904358153636317442639426.
+Reading from /dev/fibonacci at offset 698, returned the sequence 33410878289444957618607188493530847778173900120569106083403082529157749504523093168915318986912085240482480870354510205414873169790081851662484849.
+Reading from /dev/fibonacci at offset 697, returned the sequence 20649058376862930966764036030509631786019440726559168907424267534212002902244191317797589177054256850728231628400173261501031188363554465780154577.
+Reading from /dev/fibonacci at offset 696, returned the sequence 12761819912582026651843152463021215992154459394009937175978814994945746602278901851117729809857828389754249241954336943913841981426527385882330272.
+Reading from /dev/fibonacci at offset 695, returned the sequence 7887238464280904314920883567488415793864981332549231731445452539266256299965289466679859367196428460973982386445836317587189206937027079897824305.
+Reading from /dev/fibonacci at offset 694, returned the sequence 4874581448301122336922268895532800198289478061460705444533362455679490302313612384437870442661399928780266855508500626326652774489500305984505967.
+Reading from /dev/fibonacci at offset 693, returned the sequence 3012657015979781977998614671955615595575503271088526286912090083586765997651677082241988924535028532193715530937335691260536432447526773913318338.
+Reading from /dev/fibonacci at offset 692, returned the sequence 1861924432321340358923654223577184602713974790372179157621272372092724304661935302195881518126371396586551324571164935066116342041973532071187629.
+Reading from /dev/fibonacci at offset 691, returned the sequence 1150732583658441619074960448378430992861528480716347129290817711494041692989741780046107406408657135607164206366170756194420090405553241842130709.
+Reading from /dev/fibonacci at offset 690, returned the sequence 711191848662898739848693775198753609852446309655832028330454660598682611672193522149774111717714260979387118204994178871696251636420290229056920.
+Reading from /dev/fibonacci at offset 689, returned the sequence 439540734995542879226266673179677383009082171060515100960363050895359081317548257896333294690942874627777088161176577322723838769132951613073789.
+Reading from /dev/fibonacci at offset 688, returned the sequence 271651113667355860622427102019076226843364138595316927370091609703323530354645264253440817026771386351610030043817601548972412867287338615983131.
+Reading from /dev/fibonacci at offset 687, returned the sequence 167889621328187018603839571160601156165718032465198173590271441192035550962902993642892477664171488276167058117358975773751425901845612997090658.
+Reading from /dev/fibonacci at offset 686, returned the sequence 103761492339168842018587530858475070677646106130118753779820168511287979391742270610548339362599898075442971926458625775220986965441725618892473.
+Reading from /dev/fibonacci at offset 685, returned the sequence 64128128989018176585252040302126085488071926335079419810451272680747571571160723032344138301571590200724086190900349998530438936403887378198185.
+Reading from /dev/fibonacci at offset 684, returned the sequence 39633363350150665433335490556348985189574179795039333969368895830540407820581547578204201061028307874718885735558275776690548029037838240694288.
+Reading from /dev/fibonacci at offset 683, returned the sequence 24494765638867511151916549745777100298497746540040085841082376850207163750579175454139937240543282326005200455342074221839890907366049137503897.
+Reading from /dev/fibonacci at offset 682, returned the sequence 15138597711283154281418940810571884891076433254999248128286518980333244070002372124064263820485025548713685280216201554850657121671789103190391.
+Reading from /dev/fibonacci at offset 681, returned the sequence 9356167927584356870497608935205215407421313285040837712795857869873919680576803330075673420058256777291515175125872666989233785694260034313506.
+Reading from /dev/fibonacci at offset 680, returned the sequence 5782429783698797410921331875366669483655119969958410415490661110459324389425568793988590400426768771422170105090328887861423335977529068876885.
+Reading from /dev/fibonacci at offset 679, returned the sequence 3573738143885559459576277059838545923766193315082427297305196759414595291151234536087083019631488005869345070035543779127810449716730965436621.
+Reading from /dev/fibonacci at offset 678, returned the sequence 2208691639813237951345054815528123559888926654875983118185464351044729098274334257901507380795280765552825035054785108733612886260798103440264.
+Reading from /dev/fibonacci at offset 677, returned the sequence 1365046504072321508231222244310422363877266660206444179119732408369866192876900278185575638836207240316520034980758670394197563455932861996357.
+Reading from /dev/fibonacci at offset 676, returned the sequence 843645135740916443113832571217701196011659994669538939065731942674862905397433979715931741959073525236305000074026438339415322804865241443907.
+Reading from /dev/fibonacci at offset 675, returned the sequence 521401368331405065117389673092721167865606665536905240054000465695003287479466298469643896877133715080215034906732232054782240651067620552450.
+Reading from /dev/fibonacci at offset 674, returned the sequence 322243767409511377996442898124980028146053329132633699011731476979859617917967681246287845081939810156089965167294206284633082153797620891457.
+Reading from /dev/fibonacci at offset 673, returned the sequence 199157600921893687120946774967741139719553336404271541042268988715143669561498617223356051795193904924125069739438025770149158497269999660993.
+Reading from /dev/fibonacci at offset 672, returned the sequence 123086166487617690875496123157238888426499992728362157969462488264715948356469064022931793286745905231964895427856180514483923656527621230464.
+Reading from /dev/fibonacci at offset 671, returned the sequence 76071434434275996245450651810502251293053343675909383072806500450427721205029553200424258508447999692160174311581845255665234840742378430529.
+Reading from /dev/fibonacci at offset 670, returned the sequence 47014732053341694630045471346736637133446649052452774896655987814288227151439510822507534778297905539804721116274335258818688815785242799935.
+Reading from /dev/fibonacci at offset 669, returned the sequence 29056702380934301615405180463765614159606694623456608176150512636139494053590042377916723730150094152355453195307509996846546024957135630594.
+Reading from /dev/fibonacci at offset 668, returned the sequence 17958029672407393014640290882971022973839954428996166720505475178148733097849468444590811048147811387449267920966825261972142790828107169341.
+Reading from /dev/fibonacci at offset 667, returned the sequence 11098672708526908600764889580794591185766740194460441455645037457990760955740573933325912682002282764906185274340684734874403234129028461253.
+Reading from /dev/fibonacci at offset 666, returned the sequence 6859356963880484413875401302176431788073214234535725264860437720157972142108894511264898366145528622543082646626140527097739556699078708088.
+Reading from /dev/fibonacci at offset 665, returned the sequence 4239315744646424186889488278618159397693525959924716190784599737832788813631679422061014315856754142363102627714544207776663677429949753165.
+Reading from /dev/fibonacci at offset 664, returned the sequence 2620041219234060226985913023558272390379688274611009074075837982325183328477215089203884050288774480179980018911596319321075879269128954923.
+Reading from /dev/fibonacci at offset 663, returned the sequence 1619274525412363959903575255059887007313837685313707116708761755507605485154464332857130265567979662183122608802947888455587798160820798242.
+Reading from /dev/fibonacci at offset 662, returned the sequence 1000766693821696267082337768498385383065850589297301957367076226817577843322750756346753784720794817996857410108648430865488081108308156681.
+Reading from /dev/fibonacci at offset 661, returned the sequence 618507831590667692821237486561501624247987096016405159341685528690027641831713576510376480847184844186265198694299457590099717052512641561.
+Reading from /dev/fibonacci at offset 660, returned the sequence 382258862231028574261100281936883758817863493280896798025390698127550201491037179836377303873609973810592211414348973275388364055795515120.
+Reading from /dev/fibonacci at offset 659, returned the sequence 236248969359639118560137204624617865430123602735508361316294830562477440340676396673999176973574870375672987279950484314711352996717126441.
+Reading from /dev/fibonacci at offset 658, returned the sequence 146009892871389455700963077312265893387739890545388436709095867565072761150360783162378126900035103434919224134398488960677011059078388679.
+Reading from /dev/fibonacci at offset 657, returned the sequence 90239076488249662859174127312351972042383712190119924607198962997404679190315613511621050073539766940753763145551995354034341937638737762.
+Reading from /dev/fibonacci at offset 656, returned the sequence 55770816383139792841788949999913921345356178355268512101896904567668081960045169650757076826495336494165460988846493606642669121439650917.
+Reading from /dev/fibonacci at offset 655, returned the sequence 34468260105109870017385177312438050697027533834851412505302058429736597230270443860863973247044430446588302156705501747391672816199086845.
+Reading from /dev/fibonacci at offset 654, returned the sequence 21302556278029922824403772687475870648328644520417099596594846137931484729774725789893103579450906047577158832140991859250996305240564072.
+Reading from /dev/fibonacci at offset 653, returned the sequence 13165703827079947192981404624962180048698889314434312908707212291805112500495718070970869667593524399011143324564509888140676510958522773.
+Reading from /dev/fibonacci at offset 652, returned the sequence 8136852450949975631422368062513690599629755205982786687887633846126372229279007718922233911857381648566015507576481971110319794282041299.
+Reading from /dev/fibonacci at offset 651, returned the sequence 5028851376129971561559036562448489449069134108451526220819578445678740271216710352048635755736142750445127816988027917030356716676481474.
+Reading from /dev/fibonacci at offset 650, returned the sequence 3108001074820004069863331500065201150560621097531260467068055400447631958062297366873598156121238898120887690588454054079963077605559825.
+Reading from /dev/fibonacci at offset 649, returned the sequence 1920850301309967491695705062383288298508513010920265753751523045231108313154412985175037599614903852324240126399573862950393639070921649.
+Reading from /dev/fibonacci at offset 648, returned the sequence 1187150773510036578167626437681912852052108086610994713316532355216523644907884381698560556506335045796647564188880191129569438534638176.
+Reading from /dev/fibonacci at offset 647, returned the sequence 733699527799930913528078624701375446456404924309271040434990690014584668246528603476477043108568806527592562210693671820824200536283473.
+Reading from /dev/fibonacci at offset 646, returned the sequence 453451245710105664639547812980537405595703162301723672881541665201938976661355778222083513397766239269055001978186519308745237998354703.
+Reading from /dev/fibonacci at offset 645, returned the sequence 280248282089825248888530811720838040860701762007547367553449024812645691585172825254393529710802567258537560232507152512078962537928770.
+Reading from /dev/fibonacci at offset 644, returned the sequence 173202963620280415751017001259699364735001400294176305328092640389293285076182952967689983686963672010517441745679366796666275460425933.
+Reading from /dev/fibonacci at offset 643, returned the sequence 107045318469544833137513810461138676125700361713371062225356384423352406508989872286703546023838895248020118486827785715412687077502837.
+Reading from /dev/fibonacci at offset 642, returned the sequence 66157645150735582613503190798560688609301038580805243102736255965940878567193080680986437663124776762497323258851581081253588382923096.
+Reading from /dev/fibonacci at offset 641, returned the sequence 40887673318809250524010619662577987516399323132565819122620128457411527941796791605717108360714118485522795227976204634159098694579741.
+Reading from /dev/fibonacci at offset 640, returned the sequence 25269971831926332089492571135982701092901715448239423980116127508529350625396289075269329302410658276974528030875376447094489688343355.
+Reading from /dev/fibonacci at offset 639, returned the sequence 15617701486882918434518048526595286423497607684326395142504000948882177316400502530447779058303460208548267197100828187064609006236386.
+Reading from /dev/fibonacci at offset 638, returned the sequence 9652270345043413654974522609387414669404107763913028837612126559647173308995786544821550244107198068426260833774548260029880682106969.
+Reading from /dev/fibonacci at offset 637, returned the sequence 5965431141839504779543525917207871754093499920413366304891874389235004007404715985626228814196262140122006363326279927034728324129417.
+Reading from /dev/fibonacci at offset 636, returned the sequence 3686839203203908875430996692179542915310607843499662532720252170412169301591070559195321429910935928304254470448268332995152357977552.
+Reading from /dev/fibonacci at offset 635, returned the sequence 2278591938635595904112529225028328838782892076913703772171622218822834705813645426430907384285326211817751892878011594039575966151865.
+Reading from /dev/fibonacci at offset 634, returned the sequence 1408247264568312971318467467151214076527715766585958760548629951589334595777425132764414045625609716486502577570256738955576391825687.
+Reading from /dev/fibonacci at offset 633, returned the sequence 870344674067282932794061757877114762255176310327745011622992267233500110036220293666493338659716495331249315307754855083999574326178.
+Reading from /dev/fibonacci at offset 632, returned the sequence 537902590501030038524405709274099314272539456258213748925637684355834485741204839097920706965893221155253262262501883871576817499509.
+Reading from /dev/fibonacci at offset 631, returned the sequence 332442083566252894269656048603015447982636854069531262697354582877665624295015454568572631693823274175996053045252971212422756826669.
+Reading from /dev/fibonacci at offset 630, returned the sequence 205460506934777144254749660671083866289902602188682486228283101478168861446189384529348075272069946979257209217248912659154060672840.
+Reading from /dev/fibonacci at offset 629, returned the sequence 126981576631475750014906387931931581692734251880848776469071481399496762848826070039224556421753327196738843828004058553268696153829.
+Reading from /dev/fibonacci at offset 628, returned the sequence 78478930303301394239843272739152284597168350307833709759211620078672098597363314490123518850316619782518365389244854105885364519011.
+Reading from /dev/fibonacci at offset 627, returned the sequence 48502646328174355775063115192779297095565901573015066709859861320824664251462755549101037571436707414220478438759204447383331634818.
+Reading from /dev/fibonacci at offset 626, returned the sequence 29976283975127038464780157546372987501602448734818643049351758757847434345900558941022481278879912368297886950485649658502032884193.
+Reading from /dev/fibonacci at offset 625, returned the sequence 18526362353047317310282957646406309593963452838196423660508102562977229905562196608078556292556795045922591488273554788881298750625.
+Reading from /dev/fibonacci at offset 624, returned the sequence 11449921622079721154497199899966677907638995896622219388843656194870204440338362332943924986323117322375295462212094869620734133568.
+Reading from /dev/fibonacci at offset 623, returned the sequence 7076440730967596155785757746439631686324456941574204271664446368107025465223834275134631306233677723547296026061459919260564617057.
+Reading from /dev/fibonacci at offset 622, returned the sequence 4373480891112124998711442153527046221314538955048015117179209826763178975114528057809293680089439598827999436150634950360169516511.
+Reading from /dev/fibonacci at offset 621, returned the sequence 2702959839855471157074315592912585465009917986526189154485236541343846490109306217325337626144238124719296589910824968900395100546.
+Reading from /dev/fibonacci at offset 620, returned the sequence 1670521051256653841637126560614460756304620968521825962693973285419332485005221840483956053945201474108702846239809981459774415965.
+Reading from /dev/fibonacci at offset 619, returned the sequence 1032438788598817315437189032298124708705297018004363191791263255924514005104084376841381572199036650610593743671014987440620684581.
+Reading from /dev/fibonacci at offset 618, returned the sequence 638082262657836526199937528316336047599323950517462770902710029494818479901137463642574481746164823498109102568794994019153731384.
+Reading from /dev/fibonacci at offset 617, returned the sequence 394356525940980789237251503981788661105973067486900420888553226429695525202946913198807090452871827112484641102219993421466953197.
+Reading from /dev/fibonacci at offset 616, returned the sequence 243725736716855736962686024334547386493350883030562350014156803065122954698190550443767391293292996385624461466575000597686778187.
+Reading from /dev/fibonacci at offset 615, returned the sequence 150630789224125052274565479647241274612622184456338070874396423364572570504756362755039699159578830726860179635644992823780175010.
+Reading from /dev/fibonacci at offset 614, returned the sequence 93094947492730684688120544687306111880728698574224279139760379700550384193434187688727692133714165658764281830930007773906603177.
+Reading from /dev/fibonacci at offset 613, returned the sequence 57535841731394367586444934959935162731893485882113791734636043664022186311322175066312007025864665068095897804714985049873571833.
+Reading from /dev/fibonacci at offset 612, returned the sequence 35559105761336317101675609727370949148835212692110487405124336036528197882112012622415685107849500590668384026215022724033031344.
+Reading from /dev/fibonacci at offset 611, returned the sequence 21976735970058050484769325232564213583058273190003304329511707627493988429210162443896321918015164477427513778499962325840540489.
+Reading from /dev/fibonacci at offset 610, returned the sequence 13582369791278266616906284494806735565776939502107183075612628409034209452901850178519363189834336113240870247715060398192490855.
+Reading from /dev/fibonacci at offset 609, returned the sequence 8394366178779783867863040737757478017281333687896121253899079218459778976308312265376958728180828364186643530784901927648049634.
+Reading from /dev/fibonacci at offset 608, returned the sequence 5188003612498482749043243757049257548495605814211061821713549190574430476593537913142404461653507749054226716930158470544441221.
+Reading from /dev/fibonacci at offset 607, returned the sequence 3206362566281301118819796980708220468785727873685059432185530027885348499714774352234554266527320615132416813854743457103608413.
+Reading from /dev/fibonacci at offset 606, returned the sequence 1981641046217181630223446776341037079709877940526002389528019162689081976878763560907850195126187133921809903075415013440832808.
+Reading from /dev/fibonacci at offset 605, returned the sequence 1224721520064119488596350204367183389075849933159057042657510865196266522836010791326704071401133481210606910779328443662775605.
+Reading from /dev/fibonacci at offset 604, returned the sequence 756919526153062141627096571973853690634028007366945346870508297492815454042752769581146123725053652711202992296086569778057203.
+Reading from /dev/fibonacci at offset 603, returned the sequence 467801993911057346969253632393329698441821925792111695787002567703451068793258021745557947676079828499403918483241873884718402.
+Reading from /dev/fibonacci at offset 602, returned the sequence 289117532242004794657842939580523992192206081574833651083505729789364385249494747835588176048973824211799073812844695893338801.
+Reading from /dev/fibonacci at offset 601, returned the sequence 178684461669052552311410692812805706249615844217278044703496837914086683543763273909969771627106004287604844670397177991379601.
+Reading from /dev/fibonacci at offset 600, returned the sequence 110433070572952242346432246767718285942590237357555606380008891875277701705731473925618404421867819924194229142447517901959200.
+Reading from /dev/fibonacci at offset 599, returned the sequence 68251391096100309964978446045087420307025606859722438323487946038808981838031799984351367205238184363410615527949660089420401.
+Reading from /dev/fibonacci at offset 598, returned the sequence 42181679476851932381453800722630865635564630497833168056520945836468719867699673941267037216629635560783613614497857812538799.
+Reading from /dev/fibonacci at offset 597, returned the sequence 26069711619248377583524645322456554671460976361889270266967000202340261970332126043084329988608548802627001913451802276881602.
+Reading from /dev/fibonacci at offset 596, returned the sequence 16111967857603554797929155400174310964103654135943897789553945634128457897367547898182707228021086758156611701046055535657197.
+Reading from /dev/fibonacci at offset 595, returned the sequence 9957743761644822785595489922282243707357322225945372477413054568211804072964578144901622760587462044470390212405746741224405.
+Reading from /dev/fibonacci at offset 594, returned the sequence 6154224095958732012333665477892067256746331909998525312140891065916653824402969753281084467433624713686221488640308794432792.
+Reading from /dev/fibonacci at offset 593, returned the sequence 3803519665686090773261824444390176450610990315946847165272163502295150248561608391620538293153837330784168723765437946791613.
+Reading from /dev/fibonacci at offset 592, returned the sequence 2350704430272641239071841033501890806135341594051678146868727563621503575841361361660546174279787382902052764874870847641179.
+Reading from /dev/fibonacci at offset 591, returned the sequence 1452815235413449534189983410888285644475648721895169018403435938673646672720247029959992118874049947882115958890567099150434.
+Reading from /dev/fibonacci at offset 590, returned the sequence 897889194859191704881857622613605161659692872156509128465291624947856903121114331700554055405737435019936805984303748490745.
+Reading from /dev/fibonacci at offset 589, returned the sequence 554926040554257829308125788274680482815955849738659889938144313725789769599132698259438063468312512862179152906263350659689.
+Reading from /dev/fibonacci at offset 588, returned the sequence 342963154304933875573731834338924678843737022417849238527147311222067133521981633441115991937424922157757653078040397831056.
+Reading from /dev/fibonacci at offset 587, returned the sequence 211962886249323953734393953935755803972218827320810651410997002503722636077151064818322071530887590704421499828222952828633.
+Reading from /dev/fibonacci at offset 586, returned the sequence 131000268055609921839337880403168874871518195097038587116150308718344497444830568622793920406537331453336153249817445002423.
+Reading from /dev/fibonacci at offset 585, returned the sequence 80962618193714031895056073532586929100700632223772064294846693785378138632320496195528151124350259251085346578405507826210.
+Reading from /dev/fibonacci at offset 584, returned the sequence 50037649861895889944281806870581945770817562873266522821303614932966358812510072427265769282187072202250806671411937176213.
+Reading from /dev/fibonacci at offset 583, returned the sequence 30924968331818141950774266662004983329883069350505541473543078852411779819810423768262381842163187048834539906993570649997.
+Reading from /dev/fibonacci at offset 582, returned the sequence 19112681530077747993507540208576962440934493522760981347760536080554578992699648659003387440023885153416266764418366526216.
+Reading from /dev/fibonacci at offset 581, returned the sequence 11812286801740393957266726453428020888948575827744560125782542771857200827110775109258994402139301895418273142575204123781.
+Reading from /dev/fibonacci at offset 580, returned the sequence 7300394728337354036240813755148941551985917695016421221977993308697378165588873549744393037884583257997993621843162402435.
+Reading from /dev/fibonacci at offset 579, returned the sequence 4511892073403039921025912698279079336962658132728138903804549463159822661521901559514601364254718637420279520732041721346.
+Reading from /dev/fibonacci at offset 578, returned the sequence 2788502654934314115214901056869862215023259562288282318173443845537555504066971990229791673629864620577714101111120681089.
+Reading from /dev/fibonacci at offset 577, returned the sequence 1723389418468725805811011641409217121939398570439856585631105617622267157454929569284809690624854016842565419620921040257.
+Reading from /dev/fibonacci at offset 576, returned the sequence 1065113236465588309403889415460645093083860991848425732542338227915288346612042420944981983005010603735148681490199640832.
+Reading from /dev/fibonacci at offset 575, returned the sequence 658276182003137496407122225948572028855537578591430853088767389706978810842887148339827707619843413107416738130721399425.
+Reading from /dev/fibonacci at offset 574, returned the sequence 406837054462450812996767189512073064228323413256994879453570838208309535769155272605154275385167190627731943359478241407.
+Reading from /dev/fibonacci at offset 573, returned the sequence 251439127540686683410355036436498964627214165334435973635196551498669275073731875734673432234676222479684794771243158018.
+Reading from /dev/fibonacci at offset 572, returned the sequence 155397926921764129586412153075574099601109247922558905818374286709640260695423396870480843150490968148047148588235083389.
+Reading from /dev/fibonacci at offset 571, returned the sequence 96041200618922553823942883360924865026104917411877067816822264789029014378308478864192589084185254331637646183008074629.
+Reading from /dev/fibonacci at offset 570, returned the sequence 59356726302841575762469269714649234575004330510681838001552021920611246317114918006288254066305713816409502405227008760.
+Reading from /dev/fibonacci at offset 569, returned the sequence 36684474316080978061473613646275630451100586901195229815270242868417768061193560857904335017879540515228143777781065869.
+Reading from /dev/fibonacci at offset 568, returned the sequence 22672251986760597700995656068373604123903743609486608186281779052193478255921357148383919048426173301181358627445942891.
+Reading from /dev/fibonacci at offset 567, returned the sequence 14012222329320380360477957577902026327196843291708621628988463816224289805272203709520415969453367214046785150335122978.
+Reading from /dev/fibonacci at offset 566, returned the sequence 8660029657440217340517698490471577796706900317777986557293315235969188450649153438863503078972806087134573477110819913.
+Reading from /dev/fibonacci at offset 565, returned the sequence 5352192671880163019960259087430448530489942973930635071695148580255101354623050270656912890480561126912211673224303065.
+Reading from /dev/fibonacci at offset 564, returned the sequence 3307836985560054320557439403041129266216957343847351485598166655714087096026103168206590188492244960222361803886516848.
+Reading from /dev/fibonacci at offset 563, returned the sequence 2044355686320108699402819684389319264272985630083283586096981924541014258596947102450322701988316166689849869337786217.
+Reading from /dev/fibonacci at offset 562, returned the sequence 1263481299239945621154619718651810001943971713764067899501184731173072837429156065756267486503928793532511934548730631.
+Reading from /dev/fibonacci at offset 561, returned the sequence 780874387080163078248199965737509262329013916319215686595797193367941421167791036694055215484387373157337934789055586.
+Reading from /dev/fibonacci at offset 560, returned the sequence 482606912159782542906419752914300739614957797444852212905387537805131416261365029062212271019541420375173999759675045.
+Reading from /dev/fibonacci at offset 559, returned the sequence 298267474920380535341780212823208522714056118874363473690409655562810004906426007631842944464845952782163935029380541.
+Reading from /dev/fibonacci at offset 558, returned the sequence 184339437239402007564639540091092216900901678570488739214977882242321411354939021430369326554695467593010064730294504.
+Reading from /dev/fibonacci at offset 557, returned the sequence 113928037680978527777140672732116305813154440303874734475431773320488593551486986201473617910150485189153870299086037.
+Reading from /dev/fibonacci at offset 556, returned the sequence 70411399558423479787498867358975911087747238266614004739546108921832817803452035228895708644544982403856194431208467.
+Reading from /dev/fibonacci at offset 555, returned the sequence 43516638122555047989641805373140394725407202037260729735885664398655775748034950972577909265605502785297675867877570.
+Reading from /dev/fibonacci at offset 554, returned the sequence 26894761435868431797857061985835516362340036229353275003660444523177042055417084256317799378939479618558518563330897.
+Reading from /dev/fibonacci at offset 553, returned the sequence 16621876686686616191784743387304878363067165807907454732225219875478733692617866716260109886666023166739157304546673.
+Reading from /dev/fibonacci at offset 552, returned the sequence 10272884749181815606072318598530637999272870421445820271435224647698308362799217540057689492273456451819361258784224.
+Reading from /dev/fibonacci at offset 551, returned the sequence 6348991937504800585712424788774240363794295386461634460789995227780425329818649176202420394392566714919796045762449.
+Reading from /dev/fibonacci at offset 550, returned the sequence 3923892811677015020359893809756397635478575034984185810645229419917883032980568363855269097880889736899565213021775.
+Reading from /dev/fibonacci at offset 549, returned the sequence 2425099125827785565352530979017842728315720351477448650144765807862542296838080812347151296511676978020230832740674.
+Reading from /dev/fibonacci at offset 548, returned the sequence 1498793685849229455007362830738554907162854683506737160500463612055340736142487551508117801369212758879334380281101.
+Reading from /dev/fibonacci at offset 547, returned the sequence 926305439978556110345168148279287821152865667970711489644302195807201560695593260839033495142464219140896452459573.
+Reading from /dev/fibonacci at offset 546, returned the sequence 572488245870673344662194682459267086009989015536025670856161416248139175446894290669084306226748539738437927821528.
+Reading from /dev/fibonacci at offset 545, returned the sequence 353817194107882765682973465820020735142876652434685818788140779559062385248698970169949188915715679402458524638045.
+Reading from /dev/fibonacci at offset 544, returned the sequence 218671051762790578979221216639246350867112363101339852068020636689076790198195320499135117311032860335979403183483.
+Reading from /dev/fibonacci at offset 543, returned the sequence 135146142345092186703752249180774384275764289333345966720120142869985595050503649670814071604682819066479121454562.
+Reading from /dev/fibonacci at offset 542, returned the sequence 83524909417698392275468967458471966591348073767993885347900493819091195147691670828321045706350041269500281728921.
+Reading from /dev/fibonacci at offset 541, returned the sequence 51621232927393794428283281722302417684416215565352081372219649050894399902811978842493025898332777796978839725641.
+Reading from /dev/fibonacci at offset 540, returned the sequence 31903676490304597847185685736169548906931858202641803975680844768196795244879691985828019808017263472521442003280.
+Reading from /dev/fibonacci at offset 539, returned the sequence 19717556437089196581097595986132868777484357362710277396538804282697604657932286856665006090315514324457397722361.
+Reading from /dev/fibonacci at offset 538, returned the sequence 12186120053215401266088089750036680129447500839931526579142040485499190586947405129163013717701749148064044280919.
+Reading from /dev/fibonacci at offset 537, returned the sequence 7531436383873795315009506236096188648036856522778750817396763797198414070984881727501992372613765176393353441442.
+Reading from /dev/fibonacci at offset 536, returned the sequence 4654683669341605951078583513940491481410644317152775761745276688300776515962523401661021345087983971670690839477.
+Reading from /dev/fibonacci at offset 535, returned the sequence 2876752714532189363930922722155697166626212205625975055651487108897637555022358325840971027525781204722662601965.
+Reading from /dev/fibonacci at offset 534, returned the sequence 1777930954809416587147660791784794314784432111526800706093789579403138960940165075820050317562202766948028237512.
+Reading from /dev/fibonacci at offset 533, returned the sequence 1098821759722772776783261930370902851841780094099174349557697529494498594082193250020920709963578437774634364453.
+Reading from /dev/fibonacci at offset 532, returned the sequence 679109195086643810364398861413891462942652017427626356536092049908640366857971825799129607598624329173393873059.
+Reading from /dev/fibonacci at offset 531, returned the sequence 419712564636128966418863068957011388899128076671547993021605479585858227224221424221791102364954108601240491394.
+Reading from /dev/fibonacci at offset 530, returned the sequence 259396630450514843945535792456880074043523940756078363514486570322782139633750401577338505233670220572153381665.
+Reading from /dev/fibonacci at offset 529, returned the sequence 160315934185614122473327276500131314855604135915469629507118909263076087590471022644452597131283888029087109729.
+Reading from /dev/fibonacci at offset 528, returned the sequence 99080696264900721472208515956748759187919804840608734007367661059706052043279378932885908102386332543066271936.
+Reading from /dev/fibonacci at offset 527, returned the sequence 61235237920713401001118760543382555667684331074860895499751248203370035547191643711566689028897555486020837793.
+Reading from /dev/fibonacci at offset 526, returned the sequence 37845458344187320471089755413366203520235473765747838507616412856336016496087735221319219073488777057045434143.
+Reading from /dev/fibonacci at offset 525, returned the sequence 23389779576526080530029005130016352147448857309113056992134835347034019051103908490247469955408778428975403650.
+Reading from /dev/fibonacci at offset 524, returned the sequence 14455678767661239941060750283349851372786616456634781515481577509301997444983826731071749118079998628070030493.
+Reading from /dev/fibonacci at offset 523, returned the sequence 8934100808864840588968254846666500774662240852478275476653257837732021606120081759175720837328779800905373157.
+Reading from /dev/fibonacci at offset 522, returned the sequence 5521577958796399352092495436683350598124375604156506038828319671569975838863744971896028280751218827164657336.
+Reading from /dev/fibonacci at offset 521, returned the sequence 3412522850068441236875759409983150176537865248321769437824938166162045767256336787279692556577560973740715821.
+Reading from /dev/fibonacci at offset 520, returned the sequence 2109055108727958115216736026700200421586510355834736601003381505407930071607408184616335724173657853423941515.
+Reading from /dev/fibonacci at offset 519, returned the sequence 1303467741340483121659023383282949754951354892487032836821556660754115695648928602663356832403903120316774306.
+Reading from /dev/fibonacci at offset 518, returned the sequence 805587367387474993557712643417250666635155463347703764181824844653814375958479581952978891769754733107167209.
+Reading from /dev/fibonacci at offset 517, returned the sequence 497880373953008128101310739865699088316199429139329072639731816100301319690449020710377940634148387209607097.
+Reading from /dev/fibonacci at offset 516, returned the sequence 307706993434466865456401903551551578318956034208374691542093028553513056268030561242600951135606345897560112.
+Reading from /dev/fibonacci at offset 515, returned the sequence 190173380518541262644908836314147509997243394930954381097638787546788263422418459467776989498542041312046985.
+Reading from /dev/fibonacci at offset 514, returned the sequence 117533612915925602811493067237404068321712639277420310444454241006724792845612101774823961637064304585513127.
+Reading from /dev/fibonacci at offset 513, returned the sequence 72639767602615659833415769076743441675530755653534070653184546540063470576806357692953027861477736726533858.
+Reading from /dev/fibonacci at offset 512, returned the sequence 44893845313309942978077298160660626646181883623886239791269694466661322268805744081870933775586567858979269.
+Reading from /dev/fibonacci at offset 511, returned the sequence 27745922289305716855338470916082815029348872029647830861914852073402148308000613611082094085891168867554589.
+Reading from /dev/fibonacci at offset 510, returned the sequence 17147923024004226122738827244577811616833011594238408929354842393259173960805130470788839689695398991424680.
+Reading from /dev/fibonacci at offset 509, returned the sequence 10597999265301490732599643671505003412515860435409421932560009680142974347195483140293254396195769876129909.
+Reading from /dev/fibonacci at offset 508, returned the sequence 6549923758702735390139183573072808204317151158828986996794832713116199613609647330495585293499629115294771.
+Reading from /dev/fibonacci at offset 507, returned the sequence 4048075506598755342460460098432195208198709276580434935765176967026774733585835809797669102696140760835138.
+Reading from /dev/fibonacci at offset 506, returned the sequence 2501848252103980047678723474640612996118441882248552061029655746089424880023811520697916190803488354459633.
+Reading from /dev/fibonacci at offset 505, returned the sequence 1546227254494775294781736623791582212080267394331882874735521220937349853562024289099752911892652406375505.
+Reading from /dev/fibonacci at offset 504, returned the sequence 955620997609204752896986850849030784038174487916669186294134525152075026461787231598163278910835948084128.
+Reading from /dev/fibonacci at offset 503, returned the sequence 590606256885570541884749772942551428042092906415213688441386695785274827100237057501589632981816458291377.
+Reading from /dev/fibonacci at offset 502, returned the sequence 365014740723634211012237077906479355996081581501455497852747829366800199361550174096573645929019489792751.
+Reading from /dev/fibonacci at offset 501, returned the sequence 225591516161936330872512695036072072046011324913758190588638866418474627738686883405015987052796968498626.
+Reading from /dev/fibonacci at offset 500, returned the sequence 139423224561697880139724382870407283950070256587697307264108962948325571622863290691557658876222521294125.
+Reading from /dev/fibonacci at offset 499, returned the sequence 86168291600238450732788312165664788095941068326060883324529903470149056115823592713458328176574447204501.
+Reading from /dev/fibonacci at offset 498, returned the sequence 53254932961459429406936070704742495854129188261636423939579059478176515507039697978099330699648074089624.
+Reading from /dev/fibonacci at offset 497, returned the sequence 32913358638779021325852241460922292241811880064424459384950843991972540608783894735358997476926373114877.
+Reading from /dev/fibonacci at offset 496, returned the sequence 20341574322680408081083829243820203612317308197211964554628215486203974898255803242740333222721700974747.
+Reading from /dev/fibonacci at offset 495, returned the sequence 12571784316098613244768412217102088629494571867212494830322628505768565710528091492618664254204672140130.
+Reading from /dev/fibonacci at offset 494, returned the sequence 7769790006581794836315417026718114982822736329999469724305586980435409187727711750121668968517028834617.
+Reading from /dev/fibonacci at offset 493, returned the sequence 4801994309516818408452995190383973646671835537213025106017041525333156522800379742496995285687643305513.
+Reading from /dev/fibonacci at offset 492, returned the sequence 2967795697064976427862421836334141336150900792786444618288545455102252664927332007624673682829385529104.
+Reading from /dev/fibonacci at offset 491, returned the sequence 1834198612451841980590573354049832310520934744426580487728496070230903857873047734872321602858257776409.
+Reading from /dev/fibonacci at offset 490, returned the sequence 1133597084613134447271848482284309025629966048359864130560049384871348807054284272752352079971127752695.
+Reading from /dev/fibonacci at offset 489, returned the sequence 700601527838707533318724871765523284890968696066716357168446685359555050818763462119969522887130023714.
+Reading from /dev/fibonacci at offset 488, returned the sequence 432995556774426913953123610518785740738997352293147773391602699511793756235520810632382557083997728981.
+Reading from /dev/fibonacci at offset 487, returned the sequence 267605971064280619365601261246737544151971343773568583776843985847761294583242651487586965803132294733.
+Reading from /dev/fibonacci at offset 486, returned the sequence 165389585710146294587522349272048196587026008519579189614758713664032461652278159144795591280865434248.
+Reading from /dev/fibonacci at offset 485, returned the sequence 102216385354134324778078911974689347564945335253989394162085272183728832930964492342791374522266860485.
+Reading from /dev/fibonacci at offset 484, returned the sequence 63173200356011969809443437297358849022080673265589795452673441480303628721313666802004216758598573763.
+Reading from /dev/fibonacci at offset 483, returned the sequence 39043184998122354968635474677330498542864661988399598709411830703425204209650825540787157763668286722.
+Reading from /dev/fibonacci at offset 482, returned the sequence 24130015357889614840807962620028350479216011277190196743261610776878424511662841261217058994930287041.
+Reading from /dev/fibonacci at offset 481, returned the sequence 14913169640232740127827512057302148063648650711209401966150219926546779697987984279570098768737999681.
+Reading from /dev/fibonacci at offset 480, returned the sequence 9216845717656874712980450562726202415567360565980794777111390850331644813674856981646960226192287360.
+Reading from /dev/fibonacci at offset 479, returned the sequence 5696323922575865414847061494575945648081290145228607189038829076215134884313127297923138542545712321.
+Reading from /dev/fibonacci at offset 478, returned the sequence 3520521795081009298133389068150256767486070420752187588072561774116509929361729683723821683646575039.
+Reading from /dev/fibonacci at offset 477, returned the sequence 2175802127494856116713672426425688880595219724476419600966267302098624954951397614199316858899137282.
+Reading from /dev/fibonacci at offset 476, returned the sequence 1344719667586153181419716641724567886890850696275767987106294472017884974410332069524504824747437757.
+Reading from /dev/fibonacci at offset 475, returned the sequence 831082459908702935293955784701120993704369028200651613859972830080739980541065544674812034151699525.
+Reading from /dev/fibonacci at offset 474, returned the sequence 513637207677450246125760857023446893186481668075116373246321641937144993869266524849692790595738232.
+Reading from /dev/fibonacci at offset 473, returned the sequence 317445252231252689168194927677674100517887360125535240613651188143594986671799019825119243555961293.
+Reading from /dev/fibonacci at offset 472, returned the sequence 196191955446197556957565929345772792668594307949581132632670453793550007197467505024573547039776939.
+Reading from /dev/fibonacci at offset 471, returned the sequence 121253296785055132210628998331901307849293052175954107980980734350044979474331514800545696516184354.
+Reading from /dev/fibonacci at offset 470, returned the sequence 74938658661142424746936931013871484819301255773627024651689719443505027723135990224027850523592585.
+Reading from /dev/fibonacci at offset 469, returned the sequence 46314638123912707463692067318029823029991796402327083329291014906539951751195524576517845992591769.
+Reading from /dev/fibonacci at offset 468, returned the sequence 28624020537229717283244863695841661789309459371299941322398704536965075971940465647510004531000816.
+Reading from /dev/fibonacci at offset 467, returned the sequence 17690617586682990180447203622188161240682337031027142006892310369574875779255058929007841461590953.
+Reading from /dev/fibonacci at offset 466, returned the sequence 10933402950546727102797660073653500548627122340272799315506394167390200192685406718502163069409863.
+Reading from /dev/fibonacci at offset 465, returned the sequence 6757214636136263077649543548534660692055214690754342691385916202184675586569652210505678392181090.
+Reading from /dev/fibonacci at offset 464, returned the sequence 4176188314410464025148116525118839856571907649518456624120477965205524606115754507996484677228773.
+Reading from /dev/fibonacci at offset 463, returned the sequence 2581026321725799052501427023415820835483307041235886067265438236979150980453897702509193714952317.
+Reading from /dev/fibonacci at offset 462, returned the sequence 1595161992684664972646689501703019021088600608282570556855039728226373625661856805487290962276456.
+Reading from /dev/fibonacci at offset 461, returned the sequence 985864329041134079854737521712801814394706432953315510410398508752777354792040897021902752675861.
+Reading from /dev/fibonacci at offset 460, returned the sequence 609297663643530892791951979990217206693894175329255046444641219473596270869815908465388209600595.
+Reading from /dev/fibonacci at offset 459, returned the sequence 376566665397603187062785541722584607700812257624060463965757289279181083922224988556514543075266.
+Reading from /dev/fibonacci at offset 458, returned the sequence 232730998245927705729166438267632598993081917705194582478883930194415186947590919908873666525329.
+Reading from /dev/fibonacci at offset 457, returned the sequence 143835667151675481333619103454952008707730339918865881486873359084765896974634068647640876549937.
+Reading from /dev/fibonacci at offset 456, returned the sequence 88895331094252224395547334812680590285351577786328700992010571109649289972956851261232789975392.
+Reading from /dev/fibonacci at offset 455, returned the sequence 54940336057423256938071768642271418422378762132537180494862787975116607001677217386408086574545.
+Reading from /dev/fibonacci at offset 454, returned the sequence 33954995036828967457475566170409171862972815653791520497147783134532682971279633874824703400847.
+Reading from /dev/fibonacci at offset 453, returned the sequence 20985341020594289480596202471862246559405946478745659997715004840583924030397583511583383173698.
+Reading from /dev/fibonacci at offset 452, returned the sequence 12969654016234677976879363698546925303566869175045860499432778293948758940882050363241320227149.
+Reading from /dev/fibonacci at offset 451, returned the sequence 8015687004359611503716838773315321255839077303699799498282226546635165089515533148342062946549.
+Reading from /dev/fibonacci at offset 450, returned the sequence 4953967011875066473162524925231604047727791871346061001150551747313593851366517214899257280600.
+Reading from /dev/fibonacci at offset 449, returned the sequence 3061719992484545030554313848083717208111285432353738497131674799321571238149015933442805665949.
+Reading from /dev/fibonacci at offset 448, returned the sequence 1892247019390521442608211077147886839616506438992322504018876947992022613217501281456451614651.
+Reading from /dev/fibonacci at offset 447, returned the sequence 1169472973094023587946102770935830368494778993361415993112797851329548624931514651986354051298.
+Reading from /dev/fibonacci at offset 446, returned the sequence 722774046296497854662108306212056471121727445630906510906079096662473988285986629470097563353.
+Reading from /dev/fibonacci at offset 445, returned the sequence 446698926797525733283994464723773897373051547730509482206718754667074636645528022516256487945.
+Reading from /dev/fibonacci at offset 444, returned the sequence 276075119498972121378113841488282573748675897900397028699360341995399351640458606953841075408.
+Reading from /dev/fibonacci at offset 443, returned the sequence 170623807298553611905880623235491323624375649830112453507358412671675285005069415562415412537.
+Reading from /dev/fibonacci at offset 442, returned the sequence 105451312200418509472233218252791250124300248070284575192001929323724066635389191391425662871.
+Reading from /dev/fibonacci at offset 441, returned the sequence 65172495098135102433647404982700073500075401759827878315356483347951218369680224170989749666.
+Reading from /dev/fibonacci at offset 440, returned the sequence 40278817102283407038585813270091176624224846310456696876645445975772848265708967220435913205.
+Reading from /dev/fibonacci at offset 439, returned the sequence 24893677995851695395061591712608896875850555449371181438711037372178370103971256950553836461.
+Reading from /dev/fibonacci at offset 438, returned the sequence 15385139106431711643524221557482279748374290861085515437934408603594478161737710269882076744.
+Reading from /dev/fibonacci at offset 437, returned the sequence 9508538889419983751537370155126617127476264588285666000776628768583891942233546680671759717.
+Reading from /dev/fibonacci at offset 436, returned the sequence 5876600217011727891986851402355662620898026272799849437157779835010586219504163589210317027.
+Reading from /dev/fibonacci at offset 435, returned the sequence 3631938672408255859550518752770954506578238315485816563618848933573305722729383091461442690.
+Reading from /dev/fibonacci at offset 434, returned the sequence 2244661544603472032436332649584708114319787957314032873538930901437280496774780497748874337.
+Reading from /dev/fibonacci at offset 433, returned the sequence 1387277127804783827114186103186246392258450358171783690079918032136025225954602593712568353.
+Reading from /dev/fibonacci at offset 432, returned the sequence 857384416798688205322146546398461722061337599142249183459012869301255270820177904036305984.
+Reading from /dev/fibonacci at offset 431, returned the sequence 529892711006095621792039556787784670197112759029534506620905162834769955134424689676262369.
+Reading from /dev/fibonacci at offset 430, returned the sequence 327491705792592583530106989610677051864224840112714676838107706466485315685753214360043615.
+Reading from /dev/fibonacci at offset 429, returned the sequence 202401005213503038261932567177107618332887918916819829782797456368284639448671475316218754.
+Reading from /dev/fibonacci at offset 428, returned the sequence 125090700579089545268174422433569433531336921195894847055310250098200676237081739043824861.
+Reading from /dev/fibonacci at offset 427, returned the sequence 77310304634413492993758144743538184801550997720924982727487206270083963211589736272393893.
+Reading from /dev/fibonacci at offset 426, returned the sequence 47780395944676052274416277690031248729785923474969864327823043828116713025492002771430968.
+Reading from /dev/fibonacci at offset 425, returned the sequence 29529908689737440719341867053506936071765074245955118399664162441967250186097733500962925.
+Reading from /dev/fibonacci at offset 424, returned the sequence 18250487254938611555074410636524312658020849229014745928158881386149462839394269270468043.
+Reading from /dev/fibonacci at offset 423, returned the sequence 11279421434798829164267456416982623413744225016940372471505281055817787346703464230494882.
+Reading from /dev/fibonacci at offset 422, returned the sequence 6971065820139782390806954219541689244276624212074373456653600330331675492690805039973161.
+Reading from /dev/fibonacci at offset 421, returned the sequence 4308355614659046773460502197440934169467600804865999014851680725486111854012659190521721.
+Reading from /dev/fibonacci at offset 420, returned the sequence 2662710205480735617346452022100755074809023407208374441801919604845563638678145849451440.
+Reading from /dev/fibonacci at offset 419, returned the sequence 1645645409178311156114050175340179094658577397657624573049761120640548215334513341070281.
+Reading from /dev/fibonacci at offset 418, returned the sequence 1017064796302424461232401846760575980150446009550749868752158484205015423343632508381159.
+Reading from /dev/fibonacci at offset 417, returned the sequence 628580612875886694881648328579603114508131388106874704297602636435532791990880832689122.
+Reading from /dev/fibonacci at offset 416, returned the sequence 388484183426537766350753518180972865642314621443875164454555847769482631352751675692037.
+Reading from /dev/fibonacci at offset 415, returned the sequence 240096429449348928530894810398630248865816766662999539843046788666050160638129156997085.
+Reading from /dev/fibonacci at offset 414, returned the sequence 148387753977188837819858707782342616776497854780875624611509059103432470714622518694952.
+Reading from /dev/fibonacci at offset 413, returned the sequence 91708675472160090711036102616287632089318911882123915231537729562617689923506638302133.
+Reading from /dev/fibonacci at offset 412, returned the sequence 56679078505028747108822605166054984687178942898751709379971329540814780791115880392819.
+Reading from /dev/fibonacci at offset 411, returned the sequence 35029596967131343602213497450232647402139968983372205851566400021802909132390757909314.
+Reading from /dev/fibonacci at offset 410, returned the sequence 21649481537897403506609107715822337285038973915379503528404929519011871658725122483505.
+Reading from /dev/fibonacci at offset 409, returned the sequence 13380115429233940095604389734410310117100995067992702323161470502791037473665635425809.
+Reading from /dev/fibonacci at offset 408, returned the sequence 8269366108663463411004717981412027167937978847386801205243459016220834185059487057696.
+Reading from /dev/fibonacci at offset 407, returned the sequence 5110749320570476684599671752998282949163016220605901117918011486570203288606148368113.
+Reading from /dev/fibonacci at offset 406, returned the sequence 3158616788092986726405046228413744218774962626780900087325447529650630896453338689583.
+Reading from /dev/fibonacci at offset 405, returned the sequence 1952132532477489958194625524584538730388053593825001030592563956919572392152809678530.
+Reading from /dev/fibonacci at offset 404, returned the sequence 1206484255615496768210420703829205488386909032955899056732883572731058504300529011053.
+Reading from /dev/fibonacci at offset 403, returned the sequence 745648276861993189984204820755333242001144560869101973859680384188513887852280667477.
+Reading from /dev/fibonacci at offset 402, returned the sequence 460835978753503578226215883073872246385764472086797082873203188542544616448248343576.
+Reading from /dev/fibonacci at offset 401, returned the sequence 284812298108489611757988937681460995615380088782304890986477195645969271404032323901.
+Reading from /dev/fibonacci at offset 400, returned the sequence 176023680645013966468226945392411250770384383304492191886725992896575345044216019675.
+Reading from /dev/fibonacci at offset 399, returned the sequence 108788617463475645289761992289049744844995705477812699099751202749393926359816304226.
+Reading from /dev/fibonacci at offset 398, returned the sequence 67235063181538321178464953103361505925388677826679492786974790147181418684399715449.
+Reading from /dev/fibonacci at offset 397, returned the sequence 41553554281937324111297039185688238919607027651133206312776412602212507675416588777.
+Reading from /dev/fibonacci at offset 396, returned the sequence 25681508899600997067167913917673267005781650175546286474198377544968911008983126672.
+Reading from /dev/fibonacci at offset 395, returned the sequence 15872045382336327044129125268014971913825377475586919838578035057243596666433462105.
+Reading from /dev/fibonacci at offset 394, returned the sequence 9809463517264670023038788649658295091956272699959366635620342487725314342549664567.
+Reading from /dev/fibonacci at offset 393, returned the sequence 6062581865071657021090336618356676821869104775627553202957692569518282323883797538.
+Reading from /dev/fibonacci at offset 392, returned the sequence 3746881652193013001948452031301618270087167924331813432662649918207032018665867029.
+Reading from /dev/fibonacci at offset 391, returned the sequence 2315700212878644019141884587055058551781936851295739770295042651311250305217930509.
+Reading from /dev/fibonacci at offset 390, returned the sequence 1431181439314368982806567444246559718305231073036073662367607266895781713447936520.
+Reading from /dev/fibonacci at offset 389, returned the sequence 884518773564275036335317142808498833476705778259666107927435384415468591769993989.
+Reading from /dev/fibonacci at offset 388, returned the sequence 546662665750093946471250301438060884828525294776407554440171882480313121677942531.
+Reading from /dev/fibonacci at offset 387, returned the sequence 337856107814181089864066841370437948648180483483258553487263501935155470092051458.
+Reading from /dev/fibonacci at offset 386, returned the sequence 208806557935912856607183460067622936180344811293149000952908380545157651585891073.
+Reading from /dev/fibonacci at offset 385, returned the sequence 129049549878268233256883381302815012467835672190109552534355121389997818506160385.
+Reading from /dev/fibonacci at offset 384, returned the sequence 79757008057644623350300078764807923712509139103039448418553259155159833079730688.
+Reading from /dev/fibonacci at offset 383, returned the sequence 49292541820623609906583302538007088755326533087070104115801862234837985426429697.
+Reading from /dev/fibonacci at offset 382, returned the sequence 30464466237021013443716776226800834957182606015969344302751396920321847653300991.
+Reading from /dev/fibonacci at offset 381, returned the sequence 18828075583602596462866526311206253798143927071100759813050465314516137773128706.
+Reading from /dev/fibonacci at offset 380, returned the sequence 11636390653418416980850249915594581159038678944868584489700931605805709880172285.
+Reading from /dev/fibonacci at offset 379, returned the sequence 7191684930184179482016276395611672639105248126232175323349533708710427892956421.
+Reading from /dev/fibonacci at offset 378, returned the sequence 4444705723234237498833973519982908519933430818636409166351397897095281987215864.
+Reading from /dev/fibonacci at offset 377, returned the sequence 2746979206949941983182302875628764119171817307595766156998135811615145905740557.
+Reading from /dev/fibonacci at offset 376, returned the sequence 1697726516284295515651670644354144400761613511040643009353262085480136081475307.
+Reading from /dev/fibonacci at offset 375, returned the sequence 1049252690665646467530632231274619718410203796555123147644873726135009824265250.
+Reading from /dev/fibonacci at offset 374, returned the sequence 648473825618649048121038413079524682351409714485519861708388359345126257210057.
+Reading from /dev/fibonacci at offset 373, returned the sequence 400778865046997419409593818195095036058794082069603285936485366789883567055193.
+Reading from /dev/fibonacci at offset 372, returned the sequence 247694960571651628711444594884429646292615632415916575771902992555242690154864.
+Reading from /dev/fibonacci at offset 371, returned the sequence 153083904475345790698149223310665389766178449653686710164582374234640876900329.
+Reading from /dev/fibonacci at offset 370, returned the sequence 94611056096305838013295371573764256526437182762229865607320618320601813254535.
+Reading from /dev/fibonacci at offset 369, returned the sequence 58472848379039952684853851736901133239741266891456844557261755914039063645794.
+Reading from /dev/fibonacci at offset 368, returned the sequence 36138207717265885328441519836863123286695915870773021050058862406562749608741.
+Reading from /dev/fibonacci at offset 367, returned the sequence 22334640661774067356412331900038009953045351020683823507202893507476314037053.
+Reading from /dev/fibonacci at offset 366, returned the sequence 13803567055491817972029187936825113333650564850089197542855968899086435571688.
+Reading from /dev/fibonacci at offset 365, returned the sequence 8531073606282249384383143963212896619394786170594625964346924608389878465365.
+Reading from /dev/fibonacci at offset 364, returned the sequence 5272493449209568587646043973612216714255778679494571578509044290696557106323.
+Reading from /dev/fibonacci at offset 363, returned the sequence 3258580157072680796737099989600679905139007491100054385837880317693321359042.
+Reading from /dev/fibonacci at offset 362, returned the sequence 2013913292136887790908943984011536809116771188394517192671163973003235747281.
+Reading from /dev/fibonacci at offset 361, returned the sequence 1244666864935793005828156005589143096022236302705537193166716344690085611761.
+Reading from /dev/fibonacci at offset 360, returned the sequence 769246427201094785080787978422393713094534885688979999504447628313150135520.
+Reading from /dev/fibonacci at offset 359, returned the sequence 475420437734698220747368027166749382927701417016557193662268716376935476241.
+Reading from /dev/fibonacci at offset 358, returned the sequence 293825989466396564333419951255644330166833468672422805842178911936214659279.
+Reading from /dev/fibonacci at offset 357, returned the sequence 181594448268301656413948075911105052760867948344134387820089804440720816962.
+Reading from /dev/fibonacci at offset 356, returned the sequence 112231541198094907919471875344539277405965520328288418022089107495493842317.
+Reading from /dev/fibonacci at offset 355, returned the sequence 69362907070206748494476200566565775354902428015845969798000696945226974645.
+Reading from /dev/fibonacci at offset 354, returned the sequence 42868634127888159424995674777973502051063092312442448224088410550266867672.
+Reading from /dev/fibonacci at offset 353, returned the sequence 26494272942318589069480525788592273303839335703403521573912286394960106973.
+Reading from /dev/fibonacci at offset 352, returned the sequence 16374361185569570355515148989381228747223756609038926650176124155306760699.
+Reading from /dev/fibonacci at offset 351, returned the sequence 10119911756749018713965376799211044556615579094364594923736162239653346274.
+Reading from /dev/fibonacci at offset 350, returned the sequence 6254449428820551641549772190170184190608177514674331726439961915653414425.
+Reading from /dev/fibonacci at offset 349, returned the sequence 3865462327928467072415604609040860366007401579690263197296200323999931849.
+Reading from /dev/fibonacci at offset 348, returned the sequence 2388987100892084569134167581129323824600775934984068529143761591653482576.
+Reading from /dev/fibonacci at offset 347, returned the sequence 1476475227036382503281437027911536541406625644706194668152438732346449273.
+Reading from /dev/fibonacci at offset 346, returned the sequence 912511873855702065852730553217787283194150290277873860991322859307033303.
+Reading from /dev/fibonacci at offset 345, returned the sequence 563963353180680437428706474693749258212475354428320807161115873039415970.
+Reading from /dev/fibonacci at offset 344, returned the sequence 348548520675021628424024078524038024981674935849553053830206986267617333.
+Reading from /dev/fibonacci at offset 343, returned the sequence 215414832505658809004682396169711233230800418578767753330908886771798637.
+Reading from /dev/fibonacci at offset 342, returned the sequence 133133688169362819419341682354326791750874517270785300499298099495818696.
+Reading from /dev/fibonacci at offset 341, returned the sequence 82281144336295989585340713815384441479925901307982452831610787275979941.
+Reading from /dev/fibonacci at offset 340, returned the sequence 50852543833066829834000968538942350270948615962802847667687312219838755.
+Reading from /dev/fibonacci at offset 339, returned the sequence 31428600503229159751339745276442091208977285345179605163923475056141186.
+Reading from /dev/fibonacci at offset 338, returned the sequence 19423943329837670082661223262500259061971330617623242503763837163697569.
+Reading from /dev/fibonacci at offset 337, returned the sequence 12004657173391489668678522013941832147005954727556362660159637892443617.
+Reading from /dev/fibonacci at offset 336, returned the sequence 7419286156446180413982701248558426914965375890066879843604199271253952.
+Reading from /dev/fibonacci at offset 335, returned the sequence 4585371016945309254695820765383405232040578837489482816555438621189665.
+Reading from /dev/fibonacci at offset 334, returned the sequence 2833915139500871159286880483175021682924797052577397027048760650064287.
+Reading from /dev/fibonacci at offset 333, returned the sequence 1751455877444438095408940282208383549115781784912085789506677971125378.
+Reading from /dev/fibonacci at offset 332, returned the sequence 1082459262056433063877940200966638133809015267665311237542082678938909.
+Reading from /dev/fibonacci at offset 331, returned the sequence 668996615388005031531000081241745415306766517246774551964595292186469.
+Reading from /dev/fibonacci at offset 330, returned the sequence 413462646668428032346940119724892718502248750418536685577487386752440.
+Reading from /dev/fibonacci at offset 329, returned the sequence 255533968719576999184059961516852696804517766828237866387107905434029.
+Reading from /dev/fibonacci at offset 328, returned the sequence 157928677948851033162880158208040021697730983590298819190379481318411.
+Reading from /dev/fibonacci at offset 327, returned the sequence 97605290770725966021179803308812675106786783237939047196728424115618.
+Reading from /dev/fibonacci at offset 326, returned the sequence 60323387178125067141700354899227346590944200352359771993651057202793.
+Reading from /dev/fibonacci at offset 325, returned the sequence 37281903592600898879479448409585328515842582885579275203077366912825.
+Reading from /dev/fibonacci at offset 324, returned the sequence 23041483585524168262220906489642018075101617466780496790573690289968.
+Reading from /dev/fibonacci at offset 323, returned the sequence 14240420007076730617258541919943310440740965418798778412503676622857.
+Reading from /dev/fibonacci at offset 322, returned the sequence 8801063578447437644962364569698707634360652047981718378070013667111.
+Reading from /dev/fibonacci at offset 321, returned the sequence 5439356428629292972296177350244602806380313370817060034433662955746.
+Reading from /dev/fibonacci at offset 320, returned the sequence 3361707149818144672666187219454104827980338677164658343636350711365.
+Reading from /dev/fibonacci at offset 319, returned the sequence 2077649278811148299629990130790497978399974693652401690797312244381.
+Reading from /dev/fibonacci at offset 318, returned the sequence 1284057871006996373036197088663606849580363983512256652839038466984.
+Reading from /dev/fibonacci at offset 317, returned the sequence 793591407804151926593793042126891128819610710140145037958273777397.
+Reading from /dev/fibonacci at offset 316, returned the sequence 490466463202844446442404046536715720760753273372111614880764689587.
+Reading from /dev/fibonacci at offset 315, returned the sequence 303124944601307480151388995590175408058857436768033423077509087810.
+Reading from /dev/fibonacci at offset 314, returned the sequence 187341518601536966291015050946540312701895836604078191803255601777.
+Reading from /dev/fibonacci at offset 313, returned the sequence 115783425999770513860373944643635095356961600163955231274253486033.
+Reading from /dev/fibonacci at offset 312, returned the sequence 71558092601766452430641106302905217344934236440122960529002115744.
+Reading from /dev/fibonacci at offset 311, returned the sequence 44225333398004061429732838340729878012027363723832270745251370289.
+Reading from /dev/fibonacci at offset 310, returned the sequence 27332759203762391000908267962175339332906872716290689783750745455.
+Reading from /dev/fibonacci at offset 309, returned the sequence 16892574194241670428824570378554538679120491007541580961500624834.
+Reading from /dev/fibonacci at offset 308, returned the sequence 10440185009520720572083697583620800653786381708749108822250120621.
+Reading from /dev/fibonacci at offset 307, returned the sequence 6452389184720949856740872794933738025334109298792472139250504213.
+Reading from /dev/fibonacci at offset 306, returned the sequence 3987795824799770715342824788687062628452272409956636682999616408.
+Reading from /dev/fibonacci at offset 305, returned the sequence 2464593359921179141398048006246675396881836888835835456250887805.
+Reading from /dev/fibonacci at offset 304, returned the sequence 1523202464878591573944776782440387231570435521120801226748728603.
+Reading from /dev/fibonacci at offset 303, returned the sequence 941390895042587567453271223806288165311401367715034229502159202.
+Reading from /dev/fibonacci at offset 302, returned the sequence 581811569836004006491505558634099066259034153405766997246569401.
+Reading from /dev/fibonacci at offset 301, returned the sequence 359579325206583560961765665172189099052367214309267232255589801.
+Reading from /dev/fibonacci at offset 300, returned the sequence 222232244629420445529739893461909967206666939096499764990979600.
+Reading from /dev/fibonacci at offset 299, returned the sequence 137347080577163115432025771710279131845700275212767467264610201.
+Reading from /dev/fibonacci at offset 298, returned the sequence 84885164052257330097714121751630835360966663883732297726369399.
+Reading from /dev/fibonacci at offset 297, returned the sequence 52461916524905785334311649958648296484733611329035169538240802.
+Reading from /dev/fibonacci at offset 296, returned the sequence 32423247527351544763402471792982538876233052554697128188128597.
+Reading from /dev/fibonacci at offset 295, returned the sequence 20038668997554240570909178165665757608500558774338041350112205.
+Reading from /dev/fibonacci at offset 294, returned the sequence 12384578529797304192493293627316781267732493780359086838016392.
+Reading from /dev/fibonacci at offset 293, returned the sequence 7654090467756936378415884538348976340768064993978954512095813.
+Reading from /dev/fibonacci at offset 292, returned the sequence 4730488062040367814077409088967804926964428786380132325920579.
+Reading from /dev/fibonacci at offset 291, returned the sequence 2923602405716568564338475449381171413803636207598822186175234.
+Reading from /dev/fibonacci at offset 290, returned the sequence 1806885656323799249738933639586633513160792578781310139745345.
+Reading from /dev/fibonacci at offset 289, returned the sequence 1116716749392769314599541809794537900642843628817512046429889.
+Reading from /dev/fibonacci at offset 288, returned the sequence 690168906931029935139391829792095612517948949963798093315456.
+Reading from /dev/fibonacci at offset 287, returned the sequence 426547842461739379460149980002442288124894678853713953114433.
+Reading from /dev/fibonacci at offset 286, returned the sequence 263621064469290555679241849789653324393054271110084140201023.
+Reading from /dev/fibonacci at offset 285, returned the sequence 162926777992448823780908130212788963731840407743629812913410.
+Reading from /dev/fibonacci at offset 284, returned the sequence 100694286476841731898333719576864360661213863366454327287613.
+Reading from /dev/fibonacci at offset 283, returned the sequence 62232491515607091882574410635924603070626544377175485625797.
+Reading from /dev/fibonacci at offset 282, returned the sequence 38461794961234640015759308940939757590587318989278841661816.
+Reading from /dev/fibonacci at offset 281, returned the sequence 23770696554372451866815101694984845480039225387896643963981.
+Reading from /dev/fibonacci at offset 280, returned the sequence 14691098406862188148944207245954912110548093601382197697835.
+Reading from /dev/fibonacci at offset 279, returned the sequence 9079598147510263717870894449029933369491131786514446266146.
+Reading from /dev/fibonacci at offset 278, returned the sequence 5611500259351924431073312796924978741056961814867751431689.
+Reading from /dev/fibonacci at offset 277, returned the sequence 3468097888158339286797581652104954628434169971646694834457.
+Reading from /dev/fibonacci at offset 276, returned the sequence 2143402371193585144275731144820024112622791843221056597232.
+Reading from /dev/fibonacci at offset 275, returned the sequence 1324695516964754142521850507284930515811378128425638237225.
+Reading from /dev/fibonacci at offset 274, returned the sequence 818706854228831001753880637535093596811413714795418360007.
+Reading from /dev/fibonacci at offset 273, returned the sequence 505988662735923140767969869749836918999964413630219877218.
+Reading from /dev/fibonacci at offset 272, returned the sequence 312718191492907860985910767785256677811449301165198482789.
+Reading from /dev/fibonacci at offset 271, returned the sequence 193270471243015279782059101964580241188515112465021394429.
+Reading from /dev/fibonacci at offset 270, returned the sequence 119447720249892581203851665820676436622934188700177088360.
+Reading from /dev/fibonacci at offset 269, returned the sequence 73822750993122698578207436143903804565580923764844306069.
+Reading from /dev/fibonacci at offset 268, returned the sequence 45624969256769882625644229676772632057353264935332782291.
+Reading from /dev/fibonacci at offset 267, returned the sequence 28197781736352815952563206467131172508227658829511523778.
+Reading from /dev/fibonacci at offset 266, returned the sequence 17427187520417066673081023209641459549125606105821258513.
+Reading from /dev/fibonacci at offset 265, returned the sequence 10770594215935749279482183257489712959102052723690265265.
+Reading from /dev/fibonacci at offset 264, returned the sequence 6656593304481317393598839952151746590023553382130993248.
+Reading from /dev/fibonacci at offset 263, returned the sequence 4114000911454431885883343305337966369078499341559272017.
+Reading from /dev/fibonacci at offset 262, returned the sequence 2542592393026885507715496646813780220945054040571721231.
+Reading from /dev/fibonacci at offset 261, returned the sequence 1571408518427546378167846658524186148133445300987550786.
+Reading from /dev/fibonacci at offset 260, returned the sequence 971183874599339129547649988289594072811608739584170445.
+Reading from /dev/fibonacci at offset 259, returned the sequence 600224643828207248620196670234592075321836561403380341.
+Reading from /dev/fibonacci at offset 258, returned the sequence 370959230771131880927453318055001997489772178180790104.
+Reading from /dev/fibonacci at offset 257, returned the sequence 229265413057075367692743352179590077832064383222590237.
+Reading from /dev/fibonacci at offset 256, returned the sequence 141693817714056513234709965875411919657707794958199867.
+Reading from /dev/fibonacci at offset 255, returned the sequence 87571595343018854458033386304178158174356588264390370.
+Reading from /dev/fibonacci at offset 254, returned the sequence 54122222371037658776676579571233761483351206693809497.
+Reading from /dev/fibonacci at offset 253, returned the sequence 33449372971981195681356806732944396691005381570580873.
+Reading from /dev/fibonacci at offset 252, returned the sequence 20672849399056463095319772838289364792345825123228624.
+Reading from /dev/fibonacci at offset 251, returned the sequence 12776523572924732586037033894655031898659556447352249.
+Reading from /dev/fibonacci at offset 250, returned the sequence 7896325826131730509282738943634332893686268675876375.
+Reading from /dev/fibonacci at offset 249, returned the sequence 4880197746793002076754294951020699004973287771475874.
+Reading from /dev/fibonacci at offset 248, returned the sequence 3016128079338728432528443992613633888712980904400501.
+Reading from /dev/fibonacci at offset 247, returned the sequence 1864069667454273644225850958407065116260306867075373.
+Reading from /dev/fibonacci at offset 246, returned the sequence 1152058411884454788302593034206568772452674037325128.
+Reading from /dev/fibonacci at offset 245, returned the sequence 712011255569818855923257924200496343807632829750245.
+Reading from /dev/fibonacci at offset 244, returned the sequence 440047156314635932379335110006072428645041207574883.
+Reading from /dev/fibonacci at offset 243, returned the sequence 271964099255182923543922814194423915162591622175362.
+Reading from /dev/fibonacci at offset 242, returned the sequence 168083057059453008835412295811648513482449585399521.
+Reading from /dev/fibonacci at offset 241, returned the sequence 103881042195729914708510518382775401680142036775841.
+Reading from /dev/fibonacci at offset 240, returned the sequence 64202014863723094126901777428873111802307548623680.
+Reading from /dev/fibonacci at offset 239, returned the sequence 39679027332006820581608740953902289877834488152161.
+Reading from /dev/fibonacci at offset 238, returned the sequence 24522987531716273545293036474970821924473060471519.
+Reading from /dev/fibonacci at offset 237, returned the sequence 15156039800290547036315704478931467953361427680642.
+Reading from /dev/fibonacci at offset 236, returned the sequence 9366947731425726508977331996039353971111632790877.
+Reading from /dev/fibonacci at offset 235, returned the sequence 5789092068864820527338372482892113982249794889765.
+Reading from /dev/fibonacci at offset 234, returned the sequence 3577855662560905981638959513147239988861837901112.
+Reading from /dev/fibonacci at offset 233, returned the sequence 2211236406303914545699412969744873993387956988653.
+Reading from /dev/fibonacci at offset 232, returned the sequence 1366619256256991435939546543402365995473880912459.
+Reading from /dev/fibonacci at offset 231, returned the sequence 844617150046923109759866426342507997914076076194.
+Reading from /dev/fibonacci at offset 230, returned the sequence 522002106210068326179680117059857997559804836265.
+Reading from /dev/fibonacci at offset 229, returned the sequence 322615043836854783580186309282650000354271239929.
+Reading from /dev/fibonacci at offset 228, returned the sequence 199387062373213542599493807777207997205533596336.
+Reading from /dev/fibonacci at offset 227, returned the sequence 123227981463641240980692501505442003148737643593.
+Reading from /dev/fibonacci at offset 226, returned the sequence 76159080909572301618801306271765994056795952743.
+Reading from /dev/fibonacci at offset 225, returned the sequence 47068900554068939361891195233676009091941690850.
+Reading from /dev/fibonacci at offset 224, returned the sequence 29090180355503362256910111038089984964854261893.
+Reading from /dev/fibonacci at offset 223, returned the sequence 17978720198565577104981084195586024127087428957.
+Reading from /dev/fibonacci at offset 222, returned the sequence 11111460156937785151929026842503960837766832936.
+Reading from /dev/fibonacci at offset 221, returned the sequence 6867260041627791953052057353082063289320596021.
+Reading from /dev/fibonacci at offset 220, returned the sequence 4244200115309993198876969489421897548446236915.
+Reading from /dev/fibonacci at offset 219, returned the sequence 2623059926317798754175087863660165740874359106.
+Reading from /dev/fibonacci at offset 218, returned the sequence 1621140188992194444701881625761731807571877809.
+Reading from /dev/fibonacci at offset 217, returned the sequence 1001919737325604309473206237898433933302481297.
+Reading from /dev/fibonacci at offset 216, returned the sequence 619220451666590135228675387863297874269396512.
+Reading from /dev/fibonacci at offset 215, returned the sequence 382699285659014174244530850035136059033084785.
+Reading from /dev/fibonacci at offset 214, returned the sequence 236521166007575960984144537828161815236311727.
+Reading from /dev/fibonacci at offset 213, returned the sequence 146178119651438213260386312206974243796773058.
+Reading from /dev/fibonacci at offset 212, returned the sequence 90343046356137747723758225621187571439538669.
+Reading from /dev/fibonacci at offset 211, returned the sequence 55835073295300465536628086585786672357234389.
+Reading from /dev/fibonacci at offset 210, returned the sequence 34507973060837282187130139035400899082304280.
+Reading from /dev/fibonacci at offset 209, returned the sequence 21327100234463183349497947550385773274930109.
+Reading from /dev/fibonacci at offset 208, returned the sequence 13180872826374098837632191485015125807374171.
+Reading from /dev/fibonacci at offset 207, returned the sequence 8146227408089084511865756065370647467555938.
+Reading from /dev/fibonacci at offset 206, returned the sequence 5034645418285014325766435419644478339818233.
+Reading from /dev/fibonacci at offset 205, returned the sequence 3111581989804070186099320645726169127737705.
+Reading from /dev/fibonacci at offset 204, returned the sequence 1923063428480944139667114773918309212080528.
+Reading from /dev/fibonacci at offset 203, returned the sequence 1188518561323126046432205871807859915657177.
+Reading from /dev/fibonacci at offset 202, returned the sequence 734544867157818093234908902110449296423351.
+Reading from /dev/fibonacci at offset 201, returned the sequence 453973694165307953197296969697410619233826.
+Reading from /dev/fibonacci at offset 200, returned the sequence 280571172992510140037611932413038677189525.
+Reading from /dev/fibonacci at offset 199, returned the sequence 173402521172797813159685037284371942044301.
+Reading from /dev/fibonacci at offset 198, returned the sequence 107168651819712326877926895128666735145224.
+Reading from /dev/fibonacci at offset 197, returned the sequence 66233869353085486281758142155705206899077.
+Reading from /dev/fibonacci at offset 196, returned the sequence 40934782466626840596168752972961528246147.
+Reading from /dev/fibonacci at offset 195, returned the sequence 25299086886458645685589389182743678652930.
+Reading from /dev/fibonacci at offset 194, returned the sequence 15635695580168194910579363790217849593217.
+Reading from /dev/fibonacci at offset 193, returned the sequence 9663391306290450775010025392525829059713.
+Reading from /dev/fibonacci at offset 192, returned the sequence 5972304273877744135569338397692020533504.
+Reading from /dev/fibonacci at offset 191, returned the sequence 3691087032412706639440686994833808526209.
+Reading from /dev/fibonacci at offset 190, returned the sequence 2281217241465037496128651402858212007295.
+Reading from /dev/fibonacci at offset 189, returned the sequence 1409869790947669143312035591975596518914.
+Reading from /dev/fibonacci at offset 188, returned the sequence 871347450517368352816615810882615488381.
+Reading from /dev/fibonacci at offset 187, returned the sequence 538522340430300790495419781092981030533.
+Reading from /dev/fibonacci at offset 186, returned the sequence 332825110087067562321196029789634457848.
+Reading from /dev/fibonacci at offset 185, returned the sequence 205697230343233228174223751303346572685.
+Reading from /dev/fibonacci at offset 184, returned the sequence 127127879743834334146972278486287885163.
+Reading from /dev/fibonacci at offset 183, returned the sequence 78569350599398894027251472817058687522.
+Reading from /dev/fibonacci at offset 182, returned the sequence 48558529144435440119720805669229197641.
+Reading from /dev/fibonacci at offset 181, returned the sequence 30010821454963453907530667147829489881.
+Reading from /dev/fibonacci at offset 180, returned the sequence 18547707689471986212190138521399707760.
+Reading from /dev/fibonacci at offset 179, returned the sequence 11463113765491467695340528626429782121.
+Reading from /dev/fibonacci at offset 178, returned the sequence 7084593923980518516849609894969925639.
+Reading from /dev/fibonacci at offset 177, returned the sequence 4378519841510949178490918731459856482.
+Reading from /dev/fibonacci at offset 176, returned the sequence 2706074082469569338358691163510069157.
+Reading from /dev/fibonacci at offset 175, returned the sequence 1672445759041379840132227567949787325.
+Reading from /dev/fibonacci at offset 174, returned the sequence 1033628323428189498226463595560281832.
+Reading from /dev/fibonacci at offset 173, returned the sequence 638817435613190341905763972389505493.
+Reading from /dev/fibonacci at offset 172, returned the sequence 394810887814999156320699623170776339.
+Reading from /dev/fibonacci at offset 171, returned the sequence 244006547798191185585064349218729154.
+Reading from /dev/fibonacci at offset 170, returned the sequence 150804340016807970735635273952047185.
+Reading from /dev/fibonacci at offset 169, returned the sequence 93202207781383214849429075266681969.
+Reading from /dev/fibonacci at offset 168, returned the sequence 57602132235424755886206198685365216.
+Reading from /dev/fibonacci at offset 167, returned the sequence 35600075545958458963222876581316753.
+Reading from /dev/fibonacci at offset 166, returned the sequence 22002056689466296922983322104048463.
+Reading from /dev/fibonacci at offset 165, returned the sequence 13598018856492162040239554477268290.
+Reading from /dev/fibonacci at offset 164, returned the sequence 8404037832974134882743767626780173.
+Reading from /dev/fibonacci at offset 163, returned the sequence 5193981023518027157495786850488117.
+Reading from /dev/fibonacci at offset 162, returned the sequence 3210056809456107725247980776292056.
+Reading from /dev/fibonacci at offset 161, returned the sequence 1983924214061919432247806074196061.
+Reading from /dev/fibonacci at offset 160, returned the sequence 1226132595394188293000174702095995.
+Reading from /dev/fibonacci at offset 159, returned the sequence 757791618667731139247631372100066.
+Reading from /dev/fibonacci at offset 158, returned the sequence 468340976726457153752543329995929.
+Reading from /dev/fibonacci at offset 157, returned the sequence 289450641941273985495088042104137.
+Reading from /dev/fibonacci at offset 156, returned the sequence 178890334785183168257455287891792.
+Reading from /dev/fibonacci at offset 155, returned the sequence 110560307156090817237632754212345.
+Reading from /dev/fibonacci at offset 154, returned the sequence 68330027629092351019822533679447.
+Reading from /dev/fibonacci at offset 153, returned the sequence 42230279526998466217810220532898.
+Reading from /dev/fibonacci at offset 152, returned the sequence 26099748102093884802012313146549.
+Reading from /dev/fibonacci at offset 151, returned the sequence 16130531424904581415797907386349.
+Reading from /dev/fibonacci at offset 150, returned the sequence 9969216677189303386214405760200.
+Reading from /dev/fibonacci at offset 149, returned the sequence 6161314747715278029583501626149.
+Reading from /dev/fibonacci at offset 148, returned the sequence 3807901929474025356630904134051.
+Reading from /dev/fibonacci at offset 147, returned the sequence 2353412818241252672952597492098.
+Reading from /dev/fibonacci at offset 146, returned the sequence 1454489111232772683678306641953.
+Reading from /dev/fibonacci at offset 145, returned the sequence 898923707008479989274290850145.
+Reading from /dev/fibonacci at offset 144, returned the sequence 555565404224292694404015791808.
+Reading from /dev/fibonacci at offset 143, returned the sequence 343358302784187294870275058337.
+Reading from /dev/fibonacci at offset 142, returned the sequence 212207101440105399533740733471.
+Reading from /dev/fibonacci at offset 141, returned the sequence 131151201344081895336534324866.
+Reading from /dev/fibonacci at offset 140, returned the sequence 81055900096023504197206408605.
+Reading from /dev/fibonacci at offset 139, returned the sequence 50095301248058391139327916261.
+Reading from /dev/fibonacci at offset 138, returned the sequence 30960598847965113057878492344.
+Reading from /dev/fibonacci at offset 137, returned the sequence 19134702400093278081449423917.
+Reading from /dev/fibonacci at offset 136, returned the sequence 11825896447871834976429068427.
+Reading from /dev/fibonacci at offset 135, returned the sequence 7308805952221443105020355490.
+Reading from /dev/fibonacci at offset 134, returned the sequence 4517090495650391871408712937.
+Reading from /dev/fibonacci at offset 133, returned the sequence 2791715456571051233611642553.
+Reading from /dev/fibonacci at offset 132, returned the sequence 1725375039079340637797070384.
+Reading from /dev/fibonacci at offset 131, returned the sequence 1066340417491710595814572169.
+Reading from /dev/fibonacci at offset 130, returned the sequence 659034621587630041982498215.
+Reading from /dev/fibonacci at offset 129, returned the sequence 407305795904080553832073954.
+Reading from /dev/fibonacci at offset 128, returned the sequence 251728825683549488150424261.
+Reading from /dev/fibonacci at offset 127, returned the sequence 155576970220531065681649693.
+Reading from /dev/fibonacci at offset 126, returned the sequence 96151855463018422468774568.
+Reading from /dev/fibonacci at offset 125, returned the sequence 59425114757512643212875125.
+Reading from /dev/fibonacci at offset 124, returned the sequence 36726740705505779255899443.
+Reading from /dev/fibonacci at offset 123, returned the sequence 22698374052006863956975682.
+Reading from /dev/fibonacci at offset 122, returned the sequence 14028366653498915298923761.
+Reading from /dev/fibonacci at offset 121, returned the sequence 8670007398507948658051921.
+Reading from /dev/fibonacci at offset 120, returned the sequence 5358359254990966640871840.
+Reading from /dev/fibonacci at offset 119, returned the sequence 3311648143516982017180081.
+Reading from /dev/fibonacci at offset 118, returned the sequence 2046711111473984623691759.
+Reading from /dev/fibonacci at offset 117, returned the sequence 1264937032042997393488322.
+Reading from /dev/fibonacci at offset 116, returned the sequence 781774079430987230203437.
+Reading from /dev/fibonacci at offset 115, returned the sequence 483162952612010163284885.
+Reading from /dev/fibonacci at offset 114, returned the sequence 298611126818977066918552.
+Reading from /dev/fibonacci at offset 113, returned the sequence 184551825793033096366333.
+Reading from /dev/fibonacci at offset 112, returned the sequence 114059301025943970552219.
+Reading from /dev/fibonacci at offset 111, returned the sequence 70492524767089125814114.
+Reading from /dev/fibonacci at offset 110, returned the sequence 43566776258854844738105.
+Reading from /dev/fibonacci at offset 109, returned the sequence 26925748508234281076009.
+Reading from /dev/fibonacci at offset 108, returned the sequence 16641027750620563662096.
+Reading from /dev/fibonacci at offset 107, returned the sequence 10284720757613717413913.
+Reading from /dev/fibonacci at offset 106, returned the sequence 6356306993006846248183.
+Reading from /dev/fibonacci at offset 105, returned the sequence 3928413764606871165730.
+Reading from /dev/fibonacci at offset 104, returned the sequence 2427893228399975082453.
+Reading from /dev/fibonacci at offset 103, returned the sequence 1500520536206896083277.
+Reading from /dev/fibonacci at offset 102, returned the sequence 927372692193078999176.
+Reading from /dev/fibonacci at offset 101, returned the sequence 573147844013817084101.
+Reading from /dev/fibonacci at offset 100, returned the sequence 354224848179261915075.
+Reading from /dev/fibonacci at offset 99, returned the sequence 218922995834555169026.
+Reading from /dev/fibonacci at offset 98, returned the sequence 135301852344706746049.
+Reading from /dev/fibonacci at offset 97, returned the sequence 83621143489848422977.
+Reading from /dev/fibonacci at offset 96, returned the sequence 51680708854858323072.
+Reading from /dev/fibonacci at offset 95, returned the sequence 31940434634990099905.
+Reading from /dev/fibonacci at offset 94, returned the sequence 19740274219868223167.
+Reading from /dev/fibonacci at offset 93, returned the sequence 12200160415121876738.
 Reading from /dev/fibonacci at offset 92, returned the sequence 7540113804746346429.
 Reading from /dev/fibonacci at offset 91, returned the sequence 4660046610375530309.
 Reading from /dev/fibonacci at offset 90, returned the sequence 2880067194370816120.

--- a/scripts/verify.py
+++ b/scripts/verify.py
@@ -5,7 +5,7 @@ result = []
 result_split = []
 dics = []
 
-for i in range(2, 101):
+for i in range(2, 1001):
     expect.append(expect[i - 1] + expect[i - 2])
 with open('out', 'r') as f:
     tmp = f.readline()
@@ -26,3 +26,4 @@ for i in dics:
         print('input: %s' %(fib))
         print('expected: %s' %(expect[i[0]]))
         exit()
+print(f"Success, all is right.")


### PR DESCRIPTION
Instead of integer sum to use string sum.
Make fibdrv caculate over n = 93.