### PR TITLE
Fix module building failed after Linux 6.4

### DIFF
--- a/fibdrv.c
+++ b/fibdrv.c
@@ -119,10 +119,10 @@ static int __init init_fib_dev(void)
         goto failed_cdev;
     }
     fib_dev = MKDEV(major, minor);
-#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 4, 0)
-    fib_class = class_create(THIS_MODULE, DEV_FIBONACCI_NAME);
-#else
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 4, 0)
     fib_class = class_create(DEV_FIBONACCI_NAME);
+#else
+    fib_class = class_create(THIS_MODULE, DEV_FIBONACCI_NAME);
 #endif
     if (!fib_class) {
         printk(KERN_ALERT "Failed to create device class\n");

--- a/fibdrv.c
+++ b/fibdrv.c
@@ -6,6 +6,7 @@
 #include <linux/kernel.h>
 #include <linux/module.h>
 #include <linux/mutex.h>
+#include <linux/version.h>
 
 MODULE_LICENSE("Dual MIT/GPL");
 MODULE_AUTHOR("National Cheng Kung University, Taiwan");
@@ -118,9 +119,11 @@ static int __init init_fib_dev(void)
         goto failed_cdev;
     }
     fib_dev = MKDEV(major, minor);
-
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 4, 0)
     fib_class = class_create(THIS_MODULE, DEV_FIBONACCI_NAME);
-
+#else
+    fib_class = class_create(DEV_FIBONACCI_NAME);
+#endif
     if (!fib_class) {
         printk(KERN_ALERT "Failed to create device class\n");
         rc = -3;


### PR DESCRIPTION
There is the output from Linux 6.5.4 without this patch:

➜  fibdrv git:(master) make                       

Git hooks are installed successfully.

cc -o client client.c
make -C /lib/modules/6.5.4-arch2-1/build M=/home/scc/git/fibdrv modules
make[1]: Entering directory '/usr/lib/modules/6.5.4-arch2-1/build'
  CC [M]  /home/scc/git/fibdrv/fibdrv.o
/home/scc/git/fibdrv/fibdrv.c: In function ‘fib_sequence’:
/home/scc/git/fibdrv/fibdrv.c:30:5: warning: ISO C90 forbids variable length array ‘f’ [-Wvla]
   30 |     long long f[k + 2];
      |     ^~~~
In file included from ./include/linux/linkage.h:7,
                 from ./arch/x86/include/asm/cache.h:5,
                 from ./include/linux/cache.h:6,
                 from ./arch/x86/include/asm/current.h:9,
                 from ./include/linux/mutex.h:14,
                 from ./include/linux/kernfs.h:11,
                 from ./include/linux/sysfs.h:16,
                 from ./include/linux/kobject.h:20,
                 from ./include/linux/cdev.h:5,
                 from /home/scc/git/fibdrv/fibdrv.c:1:
/home/scc/git/fibdrv/fibdrv.c: In function ‘init_fib_dev’:
./include/linux/export.h:29:22: error: passing argument 1 of ‘class_create’ from incompatible pointer type [-Werror=incompatible-pointer-types]
   29 | #define THIS_MODULE (&__this_module)
      |                     ~^~~~~~~~~~~~~~~
      |                      |
      |                      struct module *
/home/scc/git/fibdrv/fibdrv.c:122:30: note: in expansion of macro ‘THIS_MODULE’
  122 |     fib_class = class_create(THIS_MODULE, DEV_FIBONACCI_NAME);
      |                              ^~~~~~~~~~~
In file included from ./include/linux/device.h:31,
                 from ./include/linux/cdev.h:8:
./include/linux/device/class.h:230:54: note: expected ‘const char *’ but argument is of type ‘struct module *’
  230 | struct class * __must_check class_create(const char *name);
      |                                          ~~~~~~~~~~~~^~~~
/home/scc/git/fibdrv/fibdrv.c:122:17: error: too many arguments to function ‘class_create’
  122 |     fib_class = class_create(THIS_MODULE, DEV_FIBONACCI_NAME);
      |                 ^~~~~~~~~~~~
./include/linux/device/class.h:230:29: note: declared here
  230 | struct class * __must_check class_create(const char *name);
      |                             ^~~~~~~~~~~~
cc1: some warnings being treated as errors
make[3]: *** [scripts/Makefile.build:243: /home/scc/git/fibdrv/fibdrv.o] Error 1
make[2]: *** [/usr/lib/modules/6.5.4-arch2-1/build/Makefile:2034: /home/scc/git/fibdrv] Error 2
make[1]: *** [Makefile:234: __sub-make] Error 2
make[1]: Leaving directory '/usr/lib/modules/6.5.4-arch2-1/build'
make: *** [Makefile:13: all] Error 2
