### PR TITLE
Suppress cppcheck warning

### DIFF
--- a/scripts/pre-commit.hook
+++ b/scripts/pre-commit.hook
@@ -9,6 +9,7 @@ CPPCHECK_suppresses=" \
 --suppress=missingIncludeSystem \
 --suppress=noValidConfiguration:fibdrv.c \
 --suppress=unusedFunction:fibdrv.c \
+--suppress=constParameterCallback:fibdrv.c \
 "
 CPPCHECK_OPTS="-I. --enable=all --error-exitcode=1 --force $CPPCHECK_suppresses $CPPCHECK_unmatched ."
 


### PR DESCRIPTION
Close #16.

The `constParameterCallback` warning occurs at [fibdrv.c:75:33](https://github.com/sysprog21/fibdrv/blob/d09711e0c115a50ebd1ef8af4c2dfb6c09adf04d/fibdrv.c#L75) when using cppcheck 2.13. Adding the `const` keyword as instructed would violate the definition of the `read` handler in `file_operations`, leading to compile error. Therefore, we suppress this warning.