### PR TITLE
Add matrix strategy to CI workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,7 +4,10 @@ on: [push, pull_request]
 
 jobs:
   fibdrv-check:
-    runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        os: [ubuntu-22.04, ubuntu-24.04]
+    runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v3.3.0
     - name: install-dependencies
@@ -20,7 +23,10 @@ jobs:
             make check
 
   coding-style:
-    runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        os: [ubuntu-22.04, ubuntu-24.04]
+    runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v3.3.0
     - name: coding convention


### PR DESCRIPTION
This PR introduces a matrix strategy to the GitHub Actions workflow, allowing the `fibdrv-check` and `coding-style` jobs to run on ubuntu-22.04 and 24.04, ensuring compatibility across different environments.

Though there is a way to share one matrix in every job as [Example: Using an output to define two matrices](https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#example-using-an-output-to-define-two-matrices) says, I decided that keeping the matrix definition within each job for code readability.